### PR TITLE
add a pgedge distributed example to postgres images

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,21 @@ docker exec -it pgedge-postgres psql -U admin example_db
 
 This repository includes two Compose examples you can try out:
 
-- Enterprise Example
+- [Enterprise Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/enterprise)
 
 Runs a single Postgres instance using the standard image and initializes extensions.
 
 - `cd examples/compose/enterprise`
-- `docker compose up`
 
 This example utilizes the standard image and handles initializing and creating extensions.
 
-- Distributed Example
+- [Distributed Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/distributed)
 
 Runs two pgEdge Postgres nodes (n1 / n2) with Spock logical replication preconfigured.
 This example demonstrates bi-directional replication and includes instructions for testing with the Northwind dataset.
 Once Postgres initialization completes, you can connect to the database in a separate shell:
 
 - `cd examples/compose/distributed`
-- `docker compose up -d`
-
-
 
 ## Data Volumes
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ This repository includes two Docker Compose examples you can try out:
   - This example runs a single Postgres instance using the standard image and initializes extensions.
 
 - [Distributed Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/distributed)
-  - This example demonstrates multi-master replication using spock
+
+  - This example runs two Postgres instances as pgEdge nodes (n1 / n2) with Spock logical replication pre-configured.
 
 ## Data Volumes
 

--- a/README.md
+++ b/README.md
@@ -64,19 +64,7 @@ This repository includes two Compose examples you can try out:
 
 - [Enterprise Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/enterprise)
 
-Runs a single Postgres instance using the standard image and initializes extensions.
-
-- `cd examples/compose/enterprise`
-
-This example utilizes the standard image and handles initializing and creating extensions.
-
 - [Distributed Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/distributed)
-
-Runs two pgEdge Postgres nodes (n1 / n2) with Spock logical replication preconfigured.
-This example demonstrates bi-directional replication and includes instructions for testing with the Northwind dataset.
-Once Postgres initialization completes, you can connect to the database in a separate shell:
-
-- `cd examples/compose/distributed`
 
 ## Data Volumes
 

--- a/README.md
+++ b/README.md
@@ -60,17 +60,26 @@ docker exec -it pgedge-postgres psql -U admin example_db
 
 ### docker compose
 
-A `docker compose` example is located at [examples/compose/enterprise](examples/compose/enterprise).
+This repository includes two Compose examples you can try out:
 
-To initialize it, go to that directory and run:
+- Enterprise Example
 
+Runs a single Postgres instance using the standard image and initializes extensions.
+
+`cd examples/compose/enterprise`
 `docker compose up`
 
 This example utilizes the standard image and handles initializing and creating extensions.
 
+- Distributed Example
+
+Runs two pgEdge Postgres nodes (n1 / n2) with Spock logical replication preconfigured.
+This example demonstrates bi-directional replication and includes instructions for testing with the Northwind dataset.
 Once Postgres initialization completes, you can connect to the database in a separate shell:
 
-`docker compose exec pgedge-postgres psql -U admin example_db`
+`cd examples/compose/distributed`
+`docker compose up -d`
+
 
 
 ## Data Volumes

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ This repository includes two Compose examples you can try out:
 
 Runs a single Postgres instance using the standard image and initializes extensions.
 
-`cd examples/compose/enterprise`
-`docker compose up`
+- `cd examples/compose/enterprise`
+- `docker compose up`
 
 This example utilizes the standard image and handles initializing and creating extensions.
 
@@ -77,8 +77,8 @@ Runs two pgEdge Postgres nodes (n1 / n2) with Spock logical replication preconfi
 This example demonstrates bi-directional replication and includes instructions for testing with the Northwind dataset.
 Once Postgres initialization completes, you can connect to the database in a separate shell:
 
-`cd examples/compose/distributed`
-`docker compose up -d`
+- `cd examples/compose/distributed`
+- `docker compose up -d`
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository provides build scripts for generating pgEdge Postgres container images supporting Postgres versions 16 and 17.
 
-Images are built from pgEdge Enterprise Postgres packages using a rockylinux9-ubi base image. 
+Images are built from pgEdge Enterprise Postgres packages using a rockylinux9-ubi base image.
 
 Images are published on the [pgEdge Github Container Registry](https://github.com/orgs/pgEdge/packages/container/package/pgedge-postgres).
 
 ## Image Flavors
 
-There are currently 2 supported image flavors: `minimal` and `standard`. 
+There are currently 2 supported image flavors: `minimal` and `standard`.
 
 Package lists contained under `packagelists` show the exact contents of each image version.
 
@@ -60,11 +60,14 @@ docker exec -it pgedge-postgres psql -U admin example_db
 
 ### docker compose
 
-This repository includes two Compose examples you can try out:
+This repository includes two Docker Compose examples you can try out:
 
 - [Enterprise Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/enterprise)
 
+  - This example runs a single Postgres instance using the standard image and initializes extensions.
+
 - [Distributed Example](https://github.com/pgEdge/postgres-images/tree/Feature/PLAT-277/Add-a-pgedge-distributed-example-to-postgres-images/examples/compose/distributed)
+  - This example demonstrates multi-master replication using spock
 
 ## Data Volumes
 
@@ -82,14 +85,14 @@ An example Docker compose spec that shows this looks like this:
 
 ```yaml
 pgedge-postgres:
-    image: ghcr.io/pgedge/pgedge-postgres:17-spock5-standard
-    restart: always
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-admin}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
-      POSTGRES_DB: ${POSTGRES_DB:-example_db}
-    volumes:
-      - data:/var/lib/pgsql
+  image: ghcr.io/pgedge/pgedge-postgres:17-spock5-standard
+  restart: always
+  environment:
+    POSTGRES_USER: ${POSTGRES_USER:-admin}
+    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+    POSTGRES_DB: ${POSTGRES_DB:-example_db}
+  volumes:
+    - data:/var/lib/pgsql
 
 volumes:
   data:

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -64,6 +64,7 @@ If you have psql, pgAdmin, or another Postgres client installed on your host mac
 
 1. First node: host=localhost port=6432 user=pgedge password=pgedge dbname=example_db.
 2. Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=example_db.
+   
 For example, using psql:
 
 ```sh
@@ -82,12 +83,13 @@ environment:
       POSTGRES_DB: example_db
       NODE_NAME: n1
 ```
-POSTGRES_USER is the name of the database superuser; the default is pgedge.
-POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
-POSTGRES_DB is the database name; the default is example_db.
-PGEDGE_USER is the name of the replication user; the default is pgedge.
-PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
-NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
+1.POSTGRES_USER is the name of the database superuser; the default is pgedge.
+2.POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
+3.POSTGRES_DB is the database name; the default is example_db.
+4.PGEDGE_USER is the name of the replication user; the default is pgedge.
+5.PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
+6.NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
+
 The ports section describes the ports in use by the node:      
 ```sh
 ports:

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -1,24 +1,25 @@
-# pgEdge Distributed Postgres  - Docker Compose Example
+# pgEdge Distributed Postgres - Docker Compose Example
 
 This example spins up two pgEdge containers (postgres-n1, postgres-n2) and configures logical replication between them using Spock. A database called example_db is created on both nodes and changes replicate bi-directionally.
 
 ## Prerequisites
 
-Docker & Docker Compose
-
-Ports 6432 and 6433 free on your host
-Using this Docker File
-
+- Install Docker and Docker Compose on your host system.
+- Ensure that port 6432 and 6433 are available on your host system.
+- Ensure that the host system has internet access to pull container images.
 
 ## Using this Docker File
+
 The docker-compose.yaml file in this repository creates a Postgres database named example_db that is replicated between two pgEdge nodes. Before running this file, ensure that you have an installed and running copy of docker with Internet access.
 
 Then, to deploy this example, use the command:
+
 ```sh
 docker compose up -d
 ```
 
 ## Connecting to example_db with psql
+
 You can interact with the database on each node of your two-node cluster with psql. For convenience, open two terminal windows, and use the following commands to connect to each node. To open a psql session on the first node, run:
 
 ```sh
@@ -26,27 +27,35 @@ docker compose exec postgres-n1 psql -U pgedge example_db
 ```
 
 Likewise, to open a `psql` session on the second node, run:
+
 ```sh
 docker compose exec postgres-n2 psql -U pgedge example_db
 ```
 
 ## Exercising Replication
+
 To demonstrate that the nodes are replicating, you can confirm that a row is replicated from a table on one node to the same table on the other node.
 
 1. Create a table on the first node:
+
 ```sh
 docker compose exec postgres-n1 psql -U pgedge example_db -c "create table example (id int primary key, data text);"
 ```
+
 2. Insert a row into our new table on the second node:
+
 ```sh
 docker compose exec postgres-n2 psql -U pgedge example_db -c "insert into example (id, data) values (1, 'Hello, pgEdge!');"
 ```
+
 3. See that the new row has replicated back to the first node:
+
 ```sh
 docker compose exec postgres-n1 psql -U pgedge example_db -c "select * from example;"
 ```
 
 ## Loading the Northwind Sample Dataset
+
 The Northwind sample dataset is a Postgres database dump that you can use to try replication with a more realistic database. To load the Northwind dataset into your pgEdge database, run:
 
 ```sh
@@ -60,11 +69,12 @@ docker compose exec postgres-n2 psql -U pgedge example_db -c "select * from nort
 ```
 
 ## Connecting to example_db from Another Client
+
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, you can use these connection strings to connect to each node:
 
 1. First node: host=localhost port=6432 user=pgedge password=pgedge dbname=example_db.
 2. Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=example_db.
-   
+
 For example, using psql:
 
 ```sh
@@ -72,6 +82,7 @@ psql 'host=localhost port=6432 user=pgedge password=pgedge dbname=example_db'
 ```
 
 ## Modifying this Example
+
 Properties specified in a service's environment define the deployment details. You can adjust these settings to customize the deployment.
 
 ```sh
@@ -83,6 +94,7 @@ environment:
       POSTGRES_DB: example_db
       NODE_NAME: n1
 ```
+
 1. POSTGRES_USER is the name of the database superuser; the default is pgedge.
 2. POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
 3. POSTGRES_DB is the database name; the default is example_db.
@@ -90,17 +102,17 @@ environment:
 5. PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
 6. NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
 
-The ports section describes the ports in use by the node:      
+The ports section describes the ports in use by the node:
+
 ```sh
 ports:
       - target: 5432
         published: 6432
 ```
 
-
-
 Our published ports are set to 6432 for postgres-n1 and 6433 for postgres-n2.
 Our .yaml file includes a clause that defines the creation of each node:
+
 ```sh
 spock-node-n1:
     content: |-
@@ -109,6 +121,7 @@ spock-node-n1:
       psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "example_db" \
         -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=example_db user=pgedge password=pgedge');"
 ```
+
 Note that this configuration only takes effect when the containers are first created. To recreate the database with a new configuration, stop the running example:
 
 ```sh

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -1,4 +1,4 @@
-# pgEdge Distributed Postgres (2-node) — Quick Start
+# pgEdge Distributed Postgres  - Docker Compose Example
 
 This example spins up two pgEdge containers (postgres-n1, postgres-n2) and configures logical replication between them using Spock. A database called example_db is created on both nodes and changes replicate bi-directionally.
 

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -1,0 +1,87 @@
+# How to run this example
+
+```sh
+docker compose up -d
+```
+
+# How to interact with this example
+
+This configuration creates a database called acctg that's replicated between two pgEdge nodes.
+
+## Connect to `acctg` with Docker
+
+To open a `psql` session on the first node, run:
+```sh
+docker compose exec postgres-n1 psql -U pgedge acctg
+```
+
+Likewise, to open a `psql` session on the second node, run:
+```sh
+docker compose exec postgres-n2 psql -U pgedge acctg
+```
+
+## Try out replication
+
+1. Create a table on the first node:
+```sh
+docker compose exec postgres-n1 psql -U pgedge acctg -c "create table example (id int primary key, data text);"
+```
+2. Insert a row into our new table on the second node:
+```sh
+docker compose exec postgres-n2 psql -U pgedge acctg -c "insert into example (id, data) values (1, 'Hello, pgEdge!');"
+```
+3. See that the new row has replicated back to the first node:
+```sh
+docker compose exec postgres-n1 psql -U pgedge acctg -c "select * from example;"
+```
+
+## Load the Northwind example dataset
+
+The Northwind example dataset is a PostgreSQL database dump that you can use to try replication with a more realistic database.  To load the Northwind dataset into your pgEdge database, run:
+
+```sh
+curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T postgres-n1 psql -U pgedge acctg
+```
+
+Now, try querying one of the new tables from the other node:
+
+```sh
+docker compose exec postgres-n2 psql -U pgedge acctg -c "select * from northwind.shippers"
+```
+
+## Connect to `acctg` from another client
+
+If you have `psql`, pgAdmin, or another client installed on your host machine, you can use these connection strings to connect to each node:
+
+- First node: `host=localhost port=6432 user=pgedge password=pgedge dbname=acctg`
+- Second node: `host=localhost port=6433 user=pgedge password=pgedge dbname=acctg`
+
+For example, using `psql`:
+
+```sh
+psql 'host=localhost port=6432 user=pgedge password=pgedge dbname=acctg'
+```
+
+# How to modify this example
+
+You can adjust settings in the docker-compose.yaml under each service’s environment:
+
+- POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB — database superuser, password, and database name (default: pgedge / pgedge / acctg)
+- PGEDGE_USER, PGEDGE_PASSWORD — application/replication user and password (default: pgedge / pgedge)
+- `nodes`: Configures the pgEdge nodes.
+- `users`: Configures which users will be created on each pgEdge node.
+- NODE_NAME — logical node name for Spock (n1 / n2)
+- Published ports are set under ports (6432 for postgres-n1, 6433 for postgres-n2)
+```sh
+
+Note that this configuration only takes effect when the containers are first created. To recreate the database with a new configuration, stop the running example:
+
+```sh
+docker compose down
+```
+
+And start it again:
+
+```sh
+docker compose up -d
+```

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -23,13 +23,13 @@ docker compose up -d
 You can interact with the database on each node of your two-node cluster with psql. For convenience, open two terminal windows, and use the following commands to connect to each node. To open a psql session on the first node, run:
 
 ```sh
-docker compose exec postgres-n1 psql -U pgedge example_db
+docker compose exec postgres-n1 psql -U admin example_db
 ```
 
 Likewise, to open a `psql` session on the second node, run:
 
 ```sh
-docker compose exec postgres-n2 psql -U pgedge example_db
+docker compose exec postgres-n2 psql -U admin example_db
 ```
 
 ## Exercising Replication
@@ -39,19 +39,19 @@ To demonstrate that the nodes are replicating, you can confirm that a row is rep
 1. Create a table on the first node:
 
 ```sh
-docker compose exec postgres-n1 psql -U pgedge example_db -c "create table example (id int primary key, data text);"
+docker compose exec postgres-n1 psql -U admin example_db -c "create table example (id int primary key, data text);"
 ```
 
 2. Insert a row into our new table on the second node:
 
 ```sh
-docker compose exec postgres-n2 psql -U pgedge example_db -c "insert into example (id, data) values (1, 'Hello, pgEdge!');"
+docker compose exec postgres-n2 psql -U admin example_db -c "insert into example (id, data) values (1, 'Hello, pgEdge!');"
 ```
 
 3. See that the new row has replicated back to the first node:
 
 ```sh
-docker compose exec postgres-n1 psql -U pgedge example_db -c "select * from example;"
+docker compose exec postgres-n1 psql -U admin example_db -c "select * from example;"
 ```
 
 ## Loading the Northwind Sample Dataset
@@ -59,13 +59,13 @@ docker compose exec postgres-n1 psql -U pgedge example_db -c "select * from exam
 The Northwind sample dataset is a Postgres database dump that you can use to try replication with a more realistic database. To load the Northwind dataset into your pgEdge database, run:
 
 ```sh
-curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T postgres-n1 psql -U pgedge example_db
+curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T postgres-n1 psql -U admin example_db
 ```
 
 Now, try querying one of the new tables from the other node:
 
 ```sh
-docker compose exec postgres-n2 psql -U pgedge example_db -c "select * from northwind.shippers"
+docker compose exec postgres-n2 psql -U admin example_db -c "select * from northwind.shippers"
 ```
 
 ## Connecting to example_db from Another Client

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -1,8 +1,8 @@
-#pgEdge Distributed Postgres (2-node) — Quick Start
+# pgEdge Distributed Postgres (2-node) — Quick Start
 
 This example spins up two pgEdge containers (postgres-n1, postgres-n2) and configures logical replication between them using Spock. A database called acctg is created on both nodes and changes replicate bi-directionally.
 
-##Prerequisites
+## Prerequisites
 
 Docker & Docker Compose
 
@@ -10,7 +10,7 @@ Ports 6432 and 6433 free on your host
 Using this Docker File
 
 
-##Using this Docker File
+## Using this Docker File
 The docker-compose.yaml file in this repository creates a Postgres database named acctg that is replicated between two pgEdge nodes. Before running this file, ensure that you have an installed and running copy of docker with Internet access.
 
 Then, to deploy this example, use the command:
@@ -18,7 +18,7 @@ Then, to deploy this example, use the command:
 docker compose up -d
 ```
 
-##Connecting to acctg with psql
+## Connecting to acctg with psql
 You can interact with the database on each node of your two-node cluster with psql. For convenience, open two terminal windows, and use the following commands to connect to each node. To open a psql session on the first node, run:
 
 ```sh
@@ -30,7 +30,7 @@ Likewise, to open a `psql` session on the second node, run:
 docker compose exec postgres-n2 psql -U pgedge acctg
 ```
 
-##Exercising Replication
+## Exercising Replication
 To demonstrate that the nodes are replicating, you can confirm that a row is replicated from a table on one node to the same table on the other node.
 
 1. Create a table on the first node:
@@ -46,7 +46,7 @@ docker compose exec postgres-n2 psql -U pgedge acctg -c "insert into example (id
 docker compose exec postgres-n1 psql -U pgedge acctg -c "select * from example;"
 ```
 
-##Loading the Northwind Sample Dataset
+## Loading the Northwind Sample Dataset
 The Northwind sample dataset is a Postgres database dump that you can use to try replication with a more realistic database. To load the Northwind dataset into your pgEdge database, run:
 
 ```sh
@@ -59,7 +59,7 @@ Now, try querying one of the new tables from the other node:
 docker compose exec postgres-n2 psql -U pgedge acctg -c "select * from northwind.shippers"
 ```
 
-##Connecting to acctg from Another Client
+## Connecting to acctg from Another Client
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, you can use these connection strings to connect to each node:
 
 First node: host=localhost port=6432 user=pgedge password=pgedge dbname=acctg
@@ -70,8 +70,7 @@ For example, using psql:
 psql 'host=localhost port=6432 user=pgedge password=pgedge dbname=acctg'
 ```
 
-# How to modify this example
-Modifying this Example
+## Modifying this Example
 Properties specified in a service's environment define the deployment details. You can adjust these settings to customize the deployment.
 
 ```sh

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -83,12 +83,12 @@ environment:
       POSTGRES_DB: example_db
       NODE_NAME: n1
 ```
-1.POSTGRES_USER is the name of the database superuser; the default is pgedge.
-2.POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
-3.POSTGRES_DB is the database name; the default is example_db.
-4.PGEDGE_USER is the name of the replication user; the default is pgedge.
-5.PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
-6.NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
+1. POSTGRES_USER is the name of the database superuser; the default is pgedge.
+2. POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
+3. POSTGRES_DB is the database name; the default is example_db.
+4. PGEDGE_USER is the name of the replication user; the default is pgedge.
+5. PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
+6. NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
 
 The ports section describes the ports in use by the node:      
 ```sh

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -62,8 +62,8 @@ docker compose exec postgres-n2 psql -U pgedge example_db -c "select * from nort
 ## Connecting to example_db from Another Client
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, you can use these connection strings to connect to each node:
 
-First node: host=localhost port=6432 user=pgedge password=pgedge dbname=example_db
-Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=example_db
+1. First node: host=localhost port=6432 user=pgedge password=pgedge dbname=example_db.
+2. Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=example_db.
 For example, using psql:
 
 ```sh

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -72,7 +72,7 @@ You can adjust settings in the docker-compose.yaml under each service’s enviro
 - `users`: Configures which users will be created on each pgEdge node.
 - NODE_NAME — logical node name for Spock (n1 / n2)
 - Published ports are set under ports (6432 for postgres-n1, 6433 for postgres-n2)
-```sh
+
 
 Note that this configuration only takes effect when the containers are first created. To recreate the database with a new configuration, stop the running example:
 

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -1,6 +1,6 @@
 # pgEdge Distributed Postgres (2-node) — Quick Start
 
-This example spins up two pgEdge containers (postgres-n1, postgres-n2) and configures logical replication between them using Spock. A database called acctg is created on both nodes and changes replicate bi-directionally.
+This example spins up two pgEdge containers (postgres-n1, postgres-n2) and configures logical replication between them using Spock. A database called example_db is created on both nodes and changes replicate bi-directionally.
 
 ## Prerequisites
 
@@ -11,23 +11,23 @@ Using this Docker File
 
 
 ## Using this Docker File
-The docker-compose.yaml file in this repository creates a Postgres database named acctg that is replicated between two pgEdge nodes. Before running this file, ensure that you have an installed and running copy of docker with Internet access.
+The docker-compose.yaml file in this repository creates a Postgres database named example_db that is replicated between two pgEdge nodes. Before running this file, ensure that you have an installed and running copy of docker with Internet access.
 
 Then, to deploy this example, use the command:
 ```sh
 docker compose up -d
 ```
 
-## Connecting to acctg with psql
+## Connecting to example_db with psql
 You can interact with the database on each node of your two-node cluster with psql. For convenience, open two terminal windows, and use the following commands to connect to each node. To open a psql session on the first node, run:
 
 ```sh
-docker compose exec postgres-n1 psql -U pgedge acctg
+docker compose exec postgres-n1 psql -U pgedge example_db
 ```
 
 Likewise, to open a `psql` session on the second node, run:
 ```sh
-docker compose exec postgres-n2 psql -U pgedge acctg
+docker compose exec postgres-n2 psql -U pgedge example_db
 ```
 
 ## Exercising Replication
@@ -35,39 +35,39 @@ To demonstrate that the nodes are replicating, you can confirm that a row is rep
 
 1. Create a table on the first node:
 ```sh
-docker compose exec postgres-n1 psql -U pgedge acctg -c "create table example (id int primary key, data text);"
+docker compose exec postgres-n1 psql -U pgedge example_db -c "create table example (id int primary key, data text);"
 ```
 2. Insert a row into our new table on the second node:
 ```sh
-docker compose exec postgres-n2 psql -U pgedge acctg -c "insert into example (id, data) values (1, 'Hello, pgEdge!');"
+docker compose exec postgres-n2 psql -U pgedge example_db -c "insert into example (id, data) values (1, 'Hello, pgEdge!');"
 ```
 3. See that the new row has replicated back to the first node:
 ```sh
-docker compose exec postgres-n1 psql -U pgedge acctg -c "select * from example;"
+docker compose exec postgres-n1 psql -U pgedge example_db -c "select * from example;"
 ```
 
 ## Loading the Northwind Sample Dataset
 The Northwind sample dataset is a Postgres database dump that you can use to try replication with a more realistic database. To load the Northwind dataset into your pgEdge database, run:
 
 ```sh
-curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T postgres-n1 psql -U pgedge acctg
+curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T postgres-n1 psql -U pgedge example_db
 ```
 
 Now, try querying one of the new tables from the other node:
 
 ```sh
-docker compose exec postgres-n2 psql -U pgedge acctg -c "select * from northwind.shippers"
+docker compose exec postgres-n2 psql -U pgedge example_db -c "select * from northwind.shippers"
 ```
 
-## Connecting to acctg from Another Client
+## Connecting to example_db from Another Client
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, you can use these connection strings to connect to each node:
 
-First node: host=localhost port=6432 user=pgedge password=pgedge dbname=acctg
-Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=acctg
+First node: host=localhost port=6432 user=pgedge password=pgedge dbname=example_db
+Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=example_db
 For example, using psql:
 
 ```sh
-psql 'host=localhost port=6432 user=pgedge password=pgedge dbname=acctg'
+psql 'host=localhost port=6432 user=pgedge password=pgedge dbname=example_db'
 ```
 
 ## Modifying this Example
@@ -79,12 +79,12 @@ environment:
       PGEDGE_PASSWORD: pgedge
       POSTGRES_USER: pgedge
       POSTGRES_PASSWORD: pgedge
-      POSTGRES_DB: acctg
+      POSTGRES_DB: example_db
       NODE_NAME: n1
 ```
 POSTGRES_USER is the name of the database superuser; the default is pgedge.
 POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
-POSTGRES_DB is the database name; the default is acctg.
+POSTGRES_DB is the database name; the default is example_db.
 PGEDGE_USER is the name of the replication user; the default is pgedge.
 PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
 NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
@@ -104,8 +104,8 @@ spock-node-n1:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
-      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
-        -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge');"
+      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "example_db" \
+        -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=example_db user=pgedge password=pgedge');"
 ```
 Note that this configuration only takes effect when the containers are first created. To recreate the database with a new configuration, stop the running example:
 

--- a/examples/compose/distributed/README.md
+++ b/examples/compose/distributed/README.md
@@ -72,13 +72,13 @@ docker compose exec postgres-n2 psql -U admin example_db -c "select * from north
 
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, you can use these connection strings to connect to each node:
 
-1. First node: host=localhost port=6432 user=pgedge password=pgedge dbname=example_db.
-2. Second node: host=localhost port=6433 user=pgedge password=pgedge dbname=example_db.
+1. First node: host=localhost port=6432 user=admin password=password dbname=example_db.
+2. Second node: host=localhost port=6433 user=admin password=password dbname=example_db.
 
 For example, using psql:
 
 ```sh
-psql 'host=localhost port=6432 user=pgedge password=pgedge dbname=example_db'
+psql 'host=localhost port=6432 user=admin password=password dbname=example_db'
 ```
 
 ## Modifying this Example
@@ -88,18 +88,18 @@ Properties specified in a service's environment define the deployment details. Y
 ```sh
 environment:
       PGEDGE_USER: pgedge
-      PGEDGE_PASSWORD: pgedge
-      POSTGRES_USER: pgedge
-      POSTGRES_PASSWORD: pgedge
+      PGEDGE_PASSWORD: password
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: example_db
       NODE_NAME: n1
 ```
 
-1. POSTGRES_USER is the name of the database superuser; the default is pgedge.
+1. POSTGRES_USER is the name of the database superuser; the default is admin.
 2. POSTGRES_PASSWORD is the password associated with the database superuser; the default is pgedge.
 3. POSTGRES_DB is the database name; the default is example_db.
 4. PGEDGE_USER is the name of the replication user; the default is pgedge.
-5. PGEDGE_PASSWORD is the password associated with the replication user; the default is pgedge.
+5. PGEDGE_PASSWORD is the password associated with the replication user; the default is password.
 6. NODE_NAME is the logical node name for the node; in our sample file, n1 and n2.
 
 The ports section describes the ports in use by the node:
@@ -119,7 +119,7 @@ spock-node-n1:
       #!/usr/bin/env bash
       set -Eeo pipefail
       psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "example_db" \
-        -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=example_db user=pgedge password=pgedge');"
+        -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=example_db user=pgedge password=password');"
 ```
 
 Note that this configuration only takes effect when the containers are first created. To recreate the database with a new configuration, stop the running example:

--- a/examples/compose/distributed/docker-compose.yaml
+++ b/examples/compose/distributed/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       PGEDGE_PASSWORD: pgedge
       POSTGRES_USER: pgedge
       POSTGRES_PASSWORD: pgedge
-      POSTGRES_DB: acctg
+      POSTGRES_DB: example_db
       NODE_NAME: n1
     ports:
       - target: 5432
@@ -34,7 +34,7 @@ services:
       - source: relax-pg-hba
         target: /docker-entrypoint-initdb.d/45-relax-pg-hba.sh
         mode: 0755
-      - source: spock-node-n1
+      - source: spock-node
         target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
         mode: 0755
 
@@ -47,7 +47,7 @@ services:
       PGEDGE_PASSWORD: pgedge
       POSTGRES_USER: pgedge
       POSTGRES_PASSWORD: pgedge
-      POSTGRES_DB: acctg
+      POSTGRES_DB: example_db
       NODE_NAME: n2
     ports:
       - target: 5432
@@ -73,10 +73,11 @@ services:
       - source: relax-pg-hba
         target: /docker-entrypoint-initdb.d/45-relax-pg-hba.sh
         mode: 0755
-      - source: spock-node-n2
+      - source: spock-node
         target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
         mode: 0755
 
+  # Generic wiring job: loops over all nodes in NODES and creates all pairwise subscriptions.
   spock-wire:
     image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
     container_name: spock-wire
@@ -85,14 +86,13 @@ services:
         condition: service_healthy
       postgres-n2:
         condition: service_healthy
+
     environment:
       PGUSER: pgedge
       PGPASSWORD: pgedge
-      DBNAME: acctg
-      N1_HOST: postgres-n1
-      N2_HOST: postgres-n2
-      N1_PORT: "5432"
-      N2_PORT: "5432"
+      DBNAME: example_db
+      # Format: name:host:port entries separated by commas. Add more nodes as needed.
+      NODES: "n1:postgres-n1:5432,n2:postgres-n2:5432"
     command: ["/bin/bash", "/wire/run.sh"]
     restart: "no"
     configs:
@@ -123,7 +123,6 @@ configs:
       echo "Initializing Spock + logical replication configuration in postgresql.conf"
 
       echo "listen_addresses = '*'"              >> "$$PGCONF"
-
       echo "wal_level = 'logical'"              >> "$$PGCONF"
       echo "max_worker_processes = 10"          >> "$$PGCONF"
       echo "max_replication_slots = 10"         >> "$$PGCONF"
@@ -164,76 +163,95 @@ configs:
       echo "host all all ::/0 md5"     >> "$$PGDATA/pg_hba.conf"
       pg_ctl -D "$$PGDATA" -m fast reload
 
-  spock-node-n1:
+  # Per-node setup: create the local spock node idempotently.
+  spock-node:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
-      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
-        -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge');"
 
-  spock-node-n2:
-    content: |-
-      #!/usr/bin/env bash
-      set -Eeo pipefail
-      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
-        -c "SELECT spock.node_create(node_name := 'n2', dsn := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge');"
+      : "$${NODE_NAME:?NODE_NAME not set}"
+      DB="$${POSTGRES_DB:-example_db}"
+      USER="$${POSTGRES_USER:-pgedge}"
+      PASS="$${POSTGRES_PASSWORD:-pgedge}"
+      HOST="postgres-$${NODE_NAME}"
+      PORT="$${PGPORT:-5432}"
+
+      export PGPASSWORD="$${PASS}"
+
+      echo "[spock-node] Ensuring spock node '$${NODE_NAME}' exists (dsn host=$${HOST} port=$${PORT})..."
+      EXISTS=$$(psql -v ON_ERROR_STOP=0 --username "$${USER}" --dbname "$${DB}" -t -A \
+        -c "SELECT 1 FROM spock.node WHERE node_name = '$${NODE_NAME}' LIMIT 1;" || true)
+
+      if [ -z "$$EXISTS" ]; then
+        psql -v ON_ERROR_STOP=1 --username "$${USER}" --dbname "$${DB}" \
+          -c "SELECT spock.node_create(node_name := '$${NODE_NAME}', dsn := 'host=$${HOST} port=$${PORT} dbname=$${DB} user=$${USER} password=$${PASS}');"
+        echo "[spock-node] node '$${NODE_NAME}' created."
+      else
+        echo "[spock-node] node '$${NODE_NAME}' already present; skipping."
+      fi
+
+  # Wiring script: builds full-mesh subscriptions across all nodes in NODES.
   spock-wire-script:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
 
+      : "$${NODES:?NODES list is required, e.g. NODES='n1:postgres-n1:5432,n2:postgres-n2:5432'}"
       : "$${PGUSER:?PGUSER required}"
       : "$${PGPASSWORD:?PGPASSWORD required}"
       : "$${DBNAME:?DBNAME required}"
-      : "$${N1_HOST:?N1_HOST required}"
-      : "$${N2_HOST:?N2_HOST required}"
-      : "$${N1_PORT:?N1_PORT required}"
-      : "$${N2_PORT:?N2_PORT required}"
 
-      echo "[wire] Waiting for $$N1_HOST:$$N1_PORT..."
-      for i in {1..120}; do
-        if pg_isready -h "$$N1_HOST" -p "$$N1_PORT" -d "$$DBNAME" -U "$$PGUSER" >/dev/null 2>&1; then
-          echo "[wire] $$N1_HOST ready."
-          break
-        fi
-        sleep 2
-        [[ $$i -eq 120 ]] && { echo "[wire] Timeout waiting for $$N1_HOST"; exit 1; }
+      IFS=',' read -r -a NODE_ENTRIES <<< "$$NODES"
+
+      # Parse into arrays
+      NAMES=()
+      HOSTS=()
+      PORTS=()
+      for entry in "$${NODE_ENTRIES[@]}"; do
+        name="$${entry%%:*}"
+        rest="$${entry#*:}"
+        host="$${rest%%:*}"
+        port="$${rest##*:}"
+        NAMES+=("$$name"); HOSTS+=("$$host"); PORTS+=("$$port")
       done
 
-      echo "[wire] Waiting for $$N2_HOST:$$N2_PORT..."
-      for i in {1..120}; do
-        if pg_isready -h "$$N2_HOST" -p "$$N2_PORT" -d "$$DBNAME" -U "$$PGUSER" >/dev/null 2>&1; then
-          echo "[wire] $$N2_HOST ready."
-          break
-        fi
-        sleep 2
-        [[ $$i -eq 120 ]] && { echo "[wire] Timeout waiting for $$N2_HOST"; exit 1; }
+      psql_ok () {
+        local host="$$1" port="$$2" sql="$$3"
+        PGPASSWORD="$$PGPASSWORD" psql -h "$$host" -p "$$port" -U "$$PGUSER" -d "$$DBNAME" -t -A -v ON_ERROR_STOP=1 -c "$$sql" >/dev/null 2>&1
+      }
+
+      echo "[wire] Waiting for all nodes to be reachable..."
+      for i in "$${!NAMES[@]}"; do
+        h="$${HOSTS[$$i]}"; p="$${PORTS[$$i]}"
+        until psql_ok "$$h" "$$p" "select 1"; do
+          echo "[wire] waiting for $$h:$$p ..."
+          sleep 1
+        done
       done
 
-      echo "[wire] Ensuring subscription on n1 (sub_n1n2)..."
-      PGPASSWORD="$$PGPASSWORD" psql -h "$$N1_HOST" -p "$$N1_PORT" -U "$$PGUSER" -d "$$DBNAME" -v ON_ERROR_STOP=1 <<'SQL'
-      DO $$$$
-      BEGIN
-        IF NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'sub_n1n2') THEN
-          PERFORM spock.sub_create(
-            subscription_name := 'sub_n1n2',
-            provider_dsn      := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge'
-          );
-        END IF;
-      END$$$$;
-      SQL
+      echo "[wire] Waiting until each DB reports its own spock.node row..."
+      for i in "$${!NAMES[@]}"; do
+        n="$${NAMES[$$i]}"; h="$${HOSTS[$$i]}"; p="$${PORTS[$$i]}"
+        until PGPASSWORD="$$PGPASSWORD" psql -h "$$h" -p "$$p" -U "$$PGUSER" -d "$$DBNAME" -t -A -c "SELECT 1 FROM spock.node WHERE node_name='$$n' LIMIT 1;" | grep -q '^1$$'; do
+          echo "[wire] waiting for spock.node '$$n' on $$h:$$p ..."
+          sleep 1
+        done
+      done
 
-      echo "[wire] Ensuring subscription on n2 (sub_n2n1)..."
-      PGPASSWORD="$$PGPASSWORD" psql -h "$$N2_HOST" -p "$$N2_PORT" -U "$$PGUSER" -d "$$DBNAME" -v ON_ERROR_STOP=1 <<'SQL'
-      DO $$$$
-      BEGIN
-        IF NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'sub_n2n1') THEN
-          PERFORM spock.sub_create(
-            subscription_name := 'sub_n2n1',
-            provider_dsn      := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge'
-          );
-        END IF;
-      END$$$$;
-      SQL
+      echo "[wire] Creating full-mesh subscriptions (idempotent)..."
+      # For every ordered pair (A,B), A!=B, ensure sub_A_B exists pointing to B
+      for i in "$${!NAMES[@]}"; do
+        ai="$${NAMES[$$i]}"; ah="$${HOSTS[$$i]}"; ap="$${PORTS[$$i]}"
+        for j in "$${!NAMES[@]}"; do
+          [ "$$i" -eq "$$j" ] && continue
+          bj="$${NAMES[$$j]}"; bh="$${HOSTS[$$j]}"; bp="$${PORTS[$$j]}"
+          sub="sub_$${ai}_$${bj}"
+          echo "[wire] ensuring $$sub exists on $$ai -> $$bj ..."
+          # single-line SQL to avoid YAML/heredoc pitfalls
+          PGPASSWORD="$$PGPASSWORD" psql -h "$$ah" -p "$$ap" -U "$$PGUSER" -d "$$DBNAME" -v ON_ERROR_STOP=1 \
+            -c "SELECT spock.sub_create(subscription_name := '$$sub', provider_dsn := 'host=$$bh port=$$bp dbname=$$DBNAME user=$$PGUSER password=$$PGPASSWORD') WHERE NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name='$$sub');" \
+            >/dev/null
+        done
+      done
 
       echo "[wire] Wiring complete."

--- a/examples/compose/distributed/docker-compose.yaml
+++ b/examples/compose/distributed/docker-compose.yaml
@@ -1,0 +1,190 @@
+services:
+  postgres-n1:
+    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
+    container_name: postgres-n1
+    restart: always
+    environment:
+      PGEDGE_USER: pgedge
+      PGEDGE_PASSWORD: pgedge
+      POSTGRES_USER: pgedge
+      POSTGRES_PASSWORD: pgedge
+      POSTGRES_DB: acctg
+      NODE_NAME: n1
+    ports:
+      - target: 5432
+        published: 6432
+    configs:
+      - source: init-extensions
+        target: /docker-entrypoint-initdb.d/10-init-extensions.sh
+        mode: 0755
+      - source: configure-spock
+        target: /docker-entrypoint-initdb.d/20-configure-spock.sh
+        mode: 0755
+      - source: restart-postgres
+        target: /docker-entrypoint-initdb.d/30-restart-postgres.sh
+        mode: 0755
+      - source: create-extensions
+        target: /docker-entrypoint-initdb.d/40-create-extensions.sh
+        mode: 0755
+      - source: relax-pg-hba
+        target: /docker-entrypoint-initdb.d/45-relax-pg-hba.sh
+        mode: 0755
+      - source: spock-node-n1
+        target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
+        mode: 0755
+      - source: final-restart
+        target: /docker-entrypoint-initdb.d/90-final-restart.sh
+        mode: 0755
+      - source: spock-sub-n1
+        target: /docker-entrypoint-initdb.d/96-spock-sub.sh
+        mode: 0755
+
+  postgres-n2:
+    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
+    container_name: postgres-n2
+    restart: always
+    environment:
+      PGEDGE_USER: pgedge
+      PGEDGE_PASSWORD: pgedge
+      POSTGRES_USER: pgedge
+      POSTGRES_PASSWORD: pgedge
+      POSTGRES_DB: acctg
+      NODE_NAME: n2
+    ports:
+      - target: 5432
+        published: 6433
+    configs:
+      - source: init-extensions
+        target: /docker-entrypoint-initdb.d/10-init-extensions.sh
+        mode: 0755
+      - source: configure-spock
+        target: /docker-entrypoint-initdb.d/20-configure-spock.sh
+        mode: 0755
+      - source: restart-postgres
+        target: /docker-entrypoint-initdb.d/30-restart-postgres.sh
+        mode: 0755
+      - source: create-extensions
+        target: /docker-entrypoint-initdb.d/40-create-extensions.sh
+        mode: 0755
+      - source: relax-pg-hba
+        target: /docker-entrypoint-initdb.d/45-relax-pg-hba.sh
+        mode: 0755
+      - source: spock-node-n2
+        target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
+        mode: 0755
+      - source: final-restart
+        target: /docker-entrypoint-initdb.d/90-final-restart.sh
+        mode: 0755
+      - source: spock-sub-n2
+        target: /docker-entrypoint-initdb.d/96-spock-sub.sh
+        mode: 0755
+
+configs:
+  init-extensions:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "postgis-3")
+      PGCONF="$$PGDATA/postgresql.conf"
+      echo "Setting shared_preload_libraries to: $${EXTENSIONS[*]}"
+      LIBS=$$(IFS=','; echo "$${EXTENSIONS[*]}")
+      if grep -q '^[ ]*shared_preload_libraries' "$$PGCONF"; then
+        sed -i "s|^[ ]*shared_preload_libraries.*|shared_preload_libraries = '$$LIBS'|" "$$PGCONF"
+      else
+        echo "shared_preload_libraries = '$$LIBS'" >> "$$PGCONF"
+      fi
+
+  configure-spock:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      PGCONF="$$PGDATA/postgresql.conf"
+      echo "Initializing Spock + logical replication configuration in postgresql.conf"
+
+      echo "listen_addresses = '*'"              >> "$$PGCONF"
+
+      # Logical replication + required knobs
+      echo "wal_level = 'logical'"              >> "$$PGCONF"
+      echo "max_worker_processes = 10"          >> "$$PGCONF"
+      echo "max_replication_slots = 10"         >> "$$PGCONF"
+      echo "max_wal_senders = 10"               >> "$$PGCONF"
+      echo "track_commit_timestamp = 'on'"      >> "$$PGCONF"
+
+      # Spock parameters
+      echo "spock.enable_ddl_replication = 'on'"       >> "$$PGCONF"
+      echo "spock.include_ddl_repset = 'on'"           >> "$$PGCONF"
+      echo "spock.allow_ddl_from_functions = 'on'"     >> "$$PGCONF"
+      echo "spock.conflict_resolution = 'last_update_wins'" >> "$$PGCONF"
+      echo "spock.save_resolutions = 'on'"             >> "$$PGCONF"
+      echo "spock.conflict_log_level = 'DEBUG'"        >> "$$PGCONF"
+
+  restart-postgres:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      echo "Mid-sequence restart to apply base configuration..."
+      pg_ctl -D "$$PGDATA" -m fast restart
+
+  create-extensions:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "postgis")
+      echo "Initializing extensions: $${EXTENSIONS[*]}"
+      for EXT in "$${EXTENSIONS[@]}"; do
+        echo "Creating extension: $$EXT"
+        psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" \
+          -c "CREATE EXTENSION IF NOT EXISTS \"$$EXT\";"
+      done
+
+  relax-pg-hba:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      echo "host all all 0.0.0.0/0 md5" >> "$$PGDATA/pg_hba.conf"
+      echo "host all all ::/0 md5"     >> "$$PGDATA/pg_hba.conf"
+      pg_ctl -D "$$PGDATA" -m fast reload
+
+  final-restart:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      echo "[final-restart] Restarting Postgres locally..."
+      pg_ctl -D "$$PGDATA" -m fast restart
+      echo "[final-restart] Restarting peer container too..."
+      if [ "$$NODE_NAME" = "n1" ]; then
+        docker restart postgres-n2 || echo "[final-restart] Could not restart postgres-n2 (maybe not available yet)"
+      else
+        docker restart postgres-n1 || echo "[final-restart] Could not restart postgres-n1 (maybe not available yet)"
+      fi
+      echo "[final-restart] Done."
+
+  spock-node-n1:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
+        -c "SELECT spock.node_create(node_name := 'n1', dsn := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge');"
+
+  spock-node-n2:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
+        -c "SELECT spock.node_create(node_name := 'n2', dsn := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge');"
+
+  spock-sub-n1:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      # n1 subscribes to n2
+      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
+        -c "SELECT spock.sub_create(subscription_name := 'sub_n1n2', provider_dsn := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge');"
+
+  spock-sub-n2:
+    content: |-
+      #!/usr/bin/env bash
+      set -Eeo pipefail
+      # n2 subscribes to n1
+      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
+        -c "SELECT spock.sub_create(subscription_name := 'sub_n2n1', provider_dsn := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge');"

--- a/examples/compose/distributed/docker-compose.yaml
+++ b/examples/compose/distributed/docker-compose.yaml
@@ -13,6 +13,11 @@ services:
     ports:
       - target: 5432
         published: 6432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -h 127.0.0.1 -p 5432"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
     configs:
       - source: init-extensions
         target: /docker-entrypoint-initdb.d/10-init-extensions.sh
@@ -32,12 +37,6 @@ services:
       - source: spock-node-n1
         target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
         mode: 0755
-      - source: final-restart
-        target: /docker-entrypoint-initdb.d/90-final-restart.sh
-        mode: 0755
-      - source: spock-sub-n1
-        target: /docker-entrypoint-initdb.d/96-spock-sub.sh
-        mode: 0755
 
   postgres-n2:
     image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
@@ -53,6 +52,11 @@ services:
     ports:
       - target: 5432
         published: 6433
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -h 127.0.0.1 -p 5432"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
     configs:
       - source: init-extensions
         target: /docker-entrypoint-initdb.d/10-init-extensions.sh
@@ -72,11 +76,28 @@ services:
       - source: spock-node-n2
         target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
         mode: 0755
-      - source: final-restart
-        target: /docker-entrypoint-initdb.d/90-final-restart.sh
-        mode: 0755
-      - source: spock-sub-n2
-        target: /docker-entrypoint-initdb.d/96-spock-sub.sh
+
+  spock-wire:
+    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
+    container_name: spock-wire
+    depends_on:
+      postgres-n1:
+        condition: service_healthy
+      postgres-n2:
+        condition: service_healthy
+    environment:
+      PGUSER: pgedge
+      PGPASSWORD: pgedge
+      DBNAME: acctg
+      N1_HOST: postgres-n1
+      N2_HOST: postgres-n2
+      N1_PORT: "5432"
+      N2_PORT: "5432"
+    command: ["/bin/bash", "/wire/run.sh"]
+    restart: "no"
+    configs:
+      - source: spock-wire-script
+        target: /wire/run.sh
         mode: 0755
 
 configs:
@@ -103,14 +124,12 @@ configs:
 
       echo "listen_addresses = '*'"              >> "$$PGCONF"
 
-      # Logical replication + required knobs
       echo "wal_level = 'logical'"              >> "$$PGCONF"
       echo "max_worker_processes = 10"          >> "$$PGCONF"
       echo "max_replication_slots = 10"         >> "$$PGCONF"
       echo "max_wal_senders = 10"               >> "$$PGCONF"
       echo "track_commit_timestamp = 'on'"      >> "$$PGCONF"
 
-      # Spock parameters
       echo "spock.enable_ddl_replication = 'on'"       >> "$$PGCONF"
       echo "spock.include_ddl_repset = 'on'"           >> "$$PGCONF"
       echo "spock.allow_ddl_from_functions = 'on'"     >> "$$PGCONF"
@@ -145,20 +164,6 @@ configs:
       echo "host all all ::/0 md5"     >> "$$PGDATA/pg_hba.conf"
       pg_ctl -D "$$PGDATA" -m fast reload
 
-  final-restart:
-    content: |-
-      #!/usr/bin/env bash
-      set -Eeo pipefail
-      echo "[final-restart] Restarting Postgres locally..."
-      pg_ctl -D "$$PGDATA" -m fast restart
-      echo "[final-restart] Restarting peer container too..."
-      if [ "$$NODE_NAME" = "n1" ]; then
-        docker restart postgres-n2 || echo "[final-restart] Could not restart postgres-n2 (maybe not available yet)"
-      else
-        docker restart postgres-n1 || echo "[final-restart] Could not restart postgres-n1 (maybe not available yet)"
-      fi
-      echo "[final-restart] Done."
-
   spock-node-n1:
     content: |-
       #!/usr/bin/env bash
@@ -172,19 +177,63 @@ configs:
       set -Eeo pipefail
       psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
         -c "SELECT spock.node_create(node_name := 'n2', dsn := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge');"
-
-  spock-sub-n1:
+  spock-wire-script:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
-      # n1 subscribes to n2
-      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
-        -c "SELECT spock.sub_create(subscription_name := 'sub_n1n2', provider_dsn := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge');"
 
-  spock-sub-n2:
-    content: |-
-      #!/usr/bin/env bash
-      set -Eeo pipefail
-      # n2 subscribes to n1
-      psql -v ON_ERROR_STOP=1 --username "pgedge" --dbname "acctg" \
-        -c "SELECT spock.sub_create(subscription_name := 'sub_n2n1', provider_dsn := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge');"
+      : "$${PGUSER:?PGUSER required}"
+      : "$${PGPASSWORD:?PGPASSWORD required}"
+      : "$${DBNAME:?DBNAME required}"
+      : "$${N1_HOST:?N1_HOST required}"
+      : "$${N2_HOST:?N2_HOST required}"
+      : "$${N1_PORT:?N1_PORT required}"
+      : "$${N2_PORT:?N2_PORT required}"
+
+      echo "[wire] Waiting for $$N1_HOST:$$N1_PORT..."
+      for i in {1..120}; do
+        if pg_isready -h "$$N1_HOST" -p "$$N1_PORT" -d "$$DBNAME" -U "$$PGUSER" >/dev/null 2>&1; then
+          echo "[wire] $$N1_HOST ready."
+          break
+        fi
+        sleep 2
+        [[ $$i -eq 120 ]] && { echo "[wire] Timeout waiting for $$N1_HOST"; exit 1; }
+      done
+
+      echo "[wire] Waiting for $$N2_HOST:$$N2_PORT..."
+      for i in {1..120}; do
+        if pg_isready -h "$$N2_HOST" -p "$$N2_PORT" -d "$$DBNAME" -U "$$PGUSER" >/dev/null 2>&1; then
+          echo "[wire] $$N2_HOST ready."
+          break
+        fi
+        sleep 2
+        [[ $$i -eq 120 ]] && { echo "[wire] Timeout waiting for $$N2_HOST"; exit 1; }
+      done
+
+      echo "[wire] Ensuring subscription on n1 (sub_n1n2)..."
+      PGPASSWORD="$$PGPASSWORD" psql -h "$$N1_HOST" -p "$$N1_PORT" -U "$$PGUSER" -d "$$DBNAME" -v ON_ERROR_STOP=1 <<'SQL'
+      DO $$$$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'sub_n1n2') THEN
+          PERFORM spock.sub_create(
+            subscription_name := 'sub_n1n2',
+            provider_dsn      := 'host=postgres-n2 port=5432 dbname=acctg user=pgedge password=pgedge'
+          );
+        END IF;
+      END$$$$;
+      SQL
+
+      echo "[wire] Ensuring subscription on n2 (sub_n2n1)..."
+      PGPASSWORD="$$PGPASSWORD" psql -h "$$N2_HOST" -p "$$N2_PORT" -U "$$PGUSER" -d "$$DBNAME" -v ON_ERROR_STOP=1 <<'SQL'
+      DO $$$$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'sub_n2n1') THEN
+          PERFORM spock.sub_create(
+            subscription_name := 'sub_n2n1',
+            provider_dsn      := 'host=postgres-n1 port=5432 dbname=acctg user=pgedge password=pgedge'
+          );
+        END IF;
+      END$$$$;
+      SQL
+
+      echo "[wire] Wiring complete."

--- a/examples/compose/distributed/docker-compose.yaml
+++ b/examples/compose/distributed/docker-compose.yaml
@@ -4,11 +4,13 @@ services:
     container_name: postgres-n1
     restart: always
     environment:
-      PGEDGE_USER: pgedge
-      PGEDGE_PASSWORD: pgedge
-      POSTGRES_USER: pgedge
-      POSTGRES_PASSWORD: pgedge
-      POSTGRES_DB: example_db
+      # Admin for initialization/configuration
+      POSTGRES_USER: ${ADMIN_USER:-admin}
+      POSTGRES_PASSWORD: ${ADMIN_PASSWORD:-password}
+      POSTGRES_DB: ${POSTGRES_DB:-example_db}
+      # Replication user (used in DSNs)
+      PGEDGE_USER: ${REPL_USER:-pgedge}
+      PGEDGE_PASSWORD: ${REPL_PASSWORD:-password}
       NODE_NAME: n1
     ports:
       - target: 5432
@@ -32,10 +34,10 @@ services:
         target: /docker-entrypoint-initdb.d/40-create-extensions.sh
         mode: 0755
       - source: relax-pg-hba
-        target: /docker-entrypoint-initdb.d/45-relax-pg-hba.sh
+        target: /docker-entrypoint-initdb.d/50-relax-pg-hba.sh
         mode: 0755
       - source: spock-node
-        target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
+        target: /docker-entrypoint-initdb.d/60-spock-node.sh
         mode: 0755
 
   postgres-n2:
@@ -43,11 +45,11 @@ services:
     container_name: postgres-n2
     restart: always
     environment:
-      PGEDGE_USER: pgedge
-      PGEDGE_PASSWORD: pgedge
-      POSTGRES_USER: pgedge
-      POSTGRES_PASSWORD: pgedge
-      POSTGRES_DB: example_db
+      POSTGRES_USER: ${ADMIN_USER:-admin}
+      POSTGRES_PASSWORD: ${ADMIN_PASSWORD:-password}
+      POSTGRES_DB: ${POSTGRES_DB:-example_db}
+      PGEDGE_USER: ${REPL_USER:-pgedge}
+      PGEDGE_PASSWORD: ${REPL_PASSWORD:-password}
       NODE_NAME: n2
     ports:
       - target: 5432
@@ -71,13 +73,13 @@ services:
         target: /docker-entrypoint-initdb.d/40-create-extensions.sh
         mode: 0755
       - source: relax-pg-hba
-        target: /docker-entrypoint-initdb.d/45-relax-pg-hba.sh
+        target: /docker-entrypoint-initdb.d/50-relax-pg-hba.sh
         mode: 0755
       - source: spock-node
-        target: /docker-entrypoint-initdb.d/50-spock-nodes.sh
+        target: /docker-entrypoint-initdb.d/60-spock-node.sh
         mode: 0755
 
-  # Generic wiring job: loops over all nodes in NODES and creates all pairwise subscriptions.
+  # Full-mesh wiring job: executes sub_create as admin; provider DSNs use the pgedge user.
   spock-wire:
     image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
     container_name: spock-wire
@@ -86,12 +88,13 @@ services:
         condition: service_healthy
       postgres-n2:
         condition: service_healthy
-
     environment:
-      PGUSER: pgedge
-      PGPASSWORD: pgedge
-      DBNAME: example_db
-      # Format: name:host:port entries separated by commas. Add more nodes as needed.
+      PGADMIN_USER: ${ADMIN_USER:-admin}
+      PGADMIN_PASSWORD: ${ADMIN_PASSWORD:-password}
+      REPL_USER: ${REPL_USER:-pgedge}
+      REPL_PASSWORD: ${REPL_PASSWORD:-password}
+      DBNAME: ${POSTGRES_DB:-example_db}
+      # name:host:port entries (extend for more nodes)
       NODES: "n1:postgres-n1:5432,n2:postgres-n2:5432"
     command: ["/bin/bash", "/wire/run.sh"]
     restart: "no"
@@ -121,14 +124,12 @@ configs:
       set -Eeo pipefail
       PGCONF="$$PGDATA/postgresql.conf"
       echo "Initializing Spock + logical replication configuration in postgresql.conf"
-
       echo "listen_addresses = '*'"              >> "$$PGCONF"
       echo "wal_level = 'logical'"              >> "$$PGCONF"
       echo "max_worker_processes = 10"          >> "$$PGCONF"
       echo "max_replication_slots = 10"         >> "$$PGCONF"
       echo "max_wal_senders = 10"               >> "$$PGCONF"
       echo "track_commit_timestamp = 'on'"      >> "$$PGCONF"
-
       echo "spock.enable_ddl_replication = 'on'"       >> "$$PGCONF"
       echo "spock.include_ddl_repset = 'on'"           >> "$$PGCONF"
       echo "spock.allow_ddl_from_functions = 'on'"     >> "$$PGCONF"
@@ -163,7 +164,7 @@ configs:
       echo "host all all ::/0 md5"     >> "$$PGDATA/pg_hba.conf"
       pg_ctl -D "$$PGDATA" -m fast reload
 
-  # Per-node setup: create the local spock node idempotently.
+  # Per-node setup: also ensures the pgedge role exists; node_create uses pgedge in DSN.
   spock-node:
     content: |-
       #!/usr/bin/env bash
@@ -171,42 +172,63 @@ configs:
 
       : "$${NODE_NAME:?NODE_NAME not set}"
       DB="$${POSTGRES_DB:-example_db}"
-      USER="$${POSTGRES_USER:-pgedge}"
-      PASS="$${POSTGRES_PASSWORD:-pgedge}"
+
+      # Admin executor (local)
+      ADMIN="$${POSTGRES_USER:-admin}"
+      ADMIN_PASS="$${POSTGRES_PASSWORD}"
+
+      # Replication user (used in DSNs)
+      REPL_USER="$${PGEDGE_USER:-pgedge}"
+      REPL_PASS="$${PGEDGE_PASSWORD:-password}"
+
       HOST="postgres-$${NODE_NAME}"
       PORT="$${PGPORT:-5432}"
 
-      export PGPASSWORD="$${PASS}"
+      export PGPASSWORD="$${ADMIN_PASS}"
 
-      echo "[spock-node] Ensuring spock node '$${NODE_NAME}' exists (dsn host=$${HOST} port=$${PORT})..."
-      EXISTS=$$(psql -v ON_ERROR_STOP=0 --username "$${USER}" --dbname "$${DB}" -t -A \
-        -c "SELECT 1 FROM spock.node WHERE node_name = '$${NODE_NAME}' LIMIT 1;" || true)
+      echo "[spock-node] Ensuring replication role '$$REPL_USER' exists and is configured..."
+      EXISTS=$$(psql -tA -U "$$ADMIN" -d "$$DB" -c "SELECT 1 FROM pg_roles WHERE rolname = '$$REPL_USER' LIMIT 1;" || true)
+      if [ "$$EXISTS" != "1" ]; then
+        psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" \
+          -c "CREATE ROLE \"$$REPL_USER\" LOGIN REPLICATION PASSWORD '$$REPL_PASS';"
+      else
+        psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" \
+          -c "ALTER ROLE \"$$REPL_USER\" LOGIN REPLICATION PASSWORD '$$REPL_PASS';"
+      fi
 
-      if [ -z "$$EXISTS" ]; then
-        psql -v ON_ERROR_STOP=1 --username "$${USER}" --dbname "$${DB}" \
-          -c "SELECT spock.node_create(node_name := '$${NODE_NAME}', dsn := 'host=$${HOST} port=$${PORT} dbname=$${DB} user=$${USER} password=$${PASS}');"
+      # Practical privileges (safe to re-run)
+      psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" -c "GRANT pg_read_all_data  TO \"$$REPL_USER\";"
+      psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" -c "GRANT pg_write_all_data TO \"$$REPL_USER\";"
+      psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" -c "GRANT CREATE, TEMP ON DATABASE \"$$DB\" TO \"$$REPL_USER\";"
+      psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES   TO \"$$REPL_USER\";"
+      psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO \"$$REPL_USER\";"
+      psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO \"$$REPL_USER\";"
+
+      echo "[spock-node] Ensuring spock node '$${NODE_NAME}' exists (dsn uses '$${REPL_USER}')..."
+      NODE_EXISTS=$$(psql -tA -U "$$ADMIN" -d "$$DB" -c "SELECT 1 FROM spock.node WHERE node_name='$${NODE_NAME}' LIMIT 1;" || true)
+      if [ "$$NODE_EXISTS" != "1" ]; then
+        psql -v ON_ERROR_STOP=1 -U "$$ADMIN" -d "$$DB" \
+          -c "SELECT spock.node_create(node_name := '$${NODE_NAME}', dsn := 'host=$${HOST} port=$${PORT} dbname=$${DB} user=$${REPL_USER} password=$${REPL_PASS}');"
         echo "[spock-node] node '$${NODE_NAME}' created."
       else
         echo "[spock-node] node '$${NODE_NAME}' already present; skipping."
       fi
 
-  # Wiring script: builds full-mesh subscriptions across all nodes in NODES.
+  # Wiring script: admin executes sub_create; provider_dsn uses replication user.
   spock-wire-script:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
 
       : "$${NODES:?NODES list is required, e.g. NODES='n1:postgres-n1:5432,n2:postgres-n2:5432'}"
-      : "$${PGUSER:?PGUSER required}"
-      : "$${PGPASSWORD:?PGPASSWORD required}"
+      : "$${PGADMIN_USER:?PGADMIN_USER required}"
+      : "$${PGADMIN_PASSWORD:?PGADMIN_PASSWORD required}"
+      : "$${REPL_USER:?REPL_USER required}"
+      : "$${REPL_PASSWORD:?REPL_PASSWORD required}"
       : "$${DBNAME:?DBNAME required}"
 
       IFS=',' read -r -a NODE_ENTRIES <<< "$$NODES"
-
-      # Parse into arrays
-      NAMES=()
-      HOSTS=()
-      PORTS=()
+      NAMES=(); HOSTS=(); PORTS=()
       for entry in "$${NODE_ENTRIES[@]}"; do
         name="$${entry%%:*}"
         rest="$${entry#*:}"
@@ -216,14 +238,14 @@ configs:
       done
 
       psql_ok () {
-        local host="$$1" port="$$2" sql="$$3"
-        PGPASSWORD="$$PGPASSWORD" psql -h "$$host" -p "$$port" -U "$$PGUSER" -d "$$DBNAME" -t -A -v ON_ERROR_STOP=1 -c "$$sql" >/dev/null 2>&1
+        local host="$$1" port="$$2" user="$$3" pass="$$4" sql="$$5"
+        PGPASSWORD="$$pass" psql -h "$$host" -p "$$port" -U "$$user" -d "$$DBNAME" -t -A -v ON_ERROR_STOP=1 -c "$$sql" >/dev/null 2>&1
       }
 
-      echo "[wire] Waiting for all nodes to be reachable..."
+      echo "[wire] Waiting for all nodes (admin access)..."
       for i in "$${!NAMES[@]}"; do
         h="$${HOSTS[$$i]}"; p="$${PORTS[$$i]}"
-        until psql_ok "$$h" "$$p" "select 1"; do
+        until psql_ok "$$h" "$$p" "$$PGADMIN_USER" "$$PGADMIN_PASSWORD" "select 1"; do
           echo "[wire] waiting for $$h:$$p ..."
           sleep 1
         done
@@ -232,14 +254,14 @@ configs:
       echo "[wire] Waiting until each DB reports its own spock.node row..."
       for i in "$${!NAMES[@]}"; do
         n="$${NAMES[$$i]}"; h="$${HOSTS[$$i]}"; p="$${PORTS[$$i]}"
-        until PGPASSWORD="$$PGPASSWORD" psql -h "$$h" -p "$$p" -U "$$PGUSER" -d "$$DBNAME" -t -A -c "SELECT 1 FROM spock.node WHERE node_name='$$n' LIMIT 1;" | grep -q '^1$$'; do
+        until PGPASSWORD="$$PGADMIN_PASSWORD" psql -h "$$h" -p "$$p" -U "$$PGADMIN_USER" -d "$$DBNAME" -t -A \
+          -c "SELECT 1 FROM spock.node WHERE node_name='$$n' LIMIT 1;" | grep -q '^1$$'; do
           echo "[wire] waiting for spock.node '$$n' on $$h:$$p ..."
           sleep 1
         done
       done
 
-      echo "[wire] Creating full-mesh subscriptions (idempotent)..."
-      # For every ordered pair (A,B), A!=B, ensure sub_A_B exists pointing to B
+      echo "[wire] Creating full-mesh subscriptions (idempotent; providers use '$$REPL_USER')..."
       for i in "$${!NAMES[@]}"; do
         ai="$${NAMES[$$i]}"; ah="$${HOSTS[$$i]}"; ap="$${PORTS[$$i]}"
         for j in "$${!NAMES[@]}"; do
@@ -247,11 +269,9 @@ configs:
           bj="$${NAMES[$$j]}"; bh="$${HOSTS[$$j]}"; bp="$${PORTS[$$j]}"
           sub="sub_$${ai}_$${bj}"
           echo "[wire] ensuring $$sub exists on $$ai -> $$bj ..."
-          # single-line SQL to avoid YAML/heredoc pitfalls
-          PGPASSWORD="$$PGPASSWORD" psql -h "$$ah" -p "$$ap" -U "$$PGUSER" -d "$$DBNAME" -v ON_ERROR_STOP=1 \
-            -c "SELECT spock.sub_create(subscription_name := '$$sub', provider_dsn := 'host=$$bh port=$$bp dbname=$$DBNAME user=$$PGUSER password=$$PGPASSWORD') WHERE NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name='$$sub');" \
+          PGPASSWORD="$$PGADMIN_PASSWORD" psql -h "$$ah" -p "$$ap" -U "$$PGADMIN_USER" -d "$$DBNAME" -v ON_ERROR_STOP=1 \
+            -c "SELECT spock.sub_create(subscription_name := '$$sub', provider_dsn := 'host=$$bh port=$$bp dbname=$$DBNAME user=$$REPL_USER password=$$REPL_PASSWORD') WHERE NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name='$$sub');" \
             >/dev/null
         done
       done
-
       echo "[wire] Wiring complete."

--- a/examples/compose/distributed/docker-compose.yaml
+++ b/examples/compose/distributed/docker-compose.yaml
@@ -108,54 +108,65 @@ configs:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
+
       EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "postgis-3")
+
       PGCONF="$$PGDATA/postgresql.conf"
+
       echo "Setting shared_preload_libraries to: $${EXTENSIONS[*]}"
+
       LIBS=$$(IFS=','; echo "$${EXTENSIONS[*]}")
+
       if grep -q '^[ ]*shared_preload_libraries' "$$PGCONF"; then
         sed -i "s|^[ ]*shared_preload_libraries.*|shared_preload_libraries = '$$LIBS'|" "$$PGCONF"
       else
         echo "shared_preload_libraries = '$$LIBS'" >> "$$PGCONF"
       fi
-
   configure-spock:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
-      PGCONF="$$PGDATA/postgresql.conf"
-      echo "Initializing Spock + logical replication configuration in postgresql.conf"
-      echo "listen_addresses = '*'"              >> "$$PGCONF"
-      echo "wal_level = 'logical'"              >> "$$PGCONF"
-      echo "max_worker_processes = 10"          >> "$$PGCONF"
-      echo "max_replication_slots = 10"         >> "$$PGCONF"
-      echo "max_wal_senders = 10"               >> "$$PGCONF"
-      echo "track_commit_timestamp = 'on'"      >> "$$PGCONF"
-      echo "spock.enable_ddl_replication = 'on'"       >> "$$PGCONF"
-      echo "spock.include_ddl_repset = 'on'"           >> "$$PGCONF"
-      echo "spock.allow_ddl_from_functions = 'on'"     >> "$$PGCONF"
-      echo "spock.conflict_resolution = 'last_update_wins'" >> "$$PGCONF"
-      echo "spock.save_resolutions = 'on'"             >> "$$PGCONF"
-      echo "spock.conflict_log_level = 'DEBUG'"        >> "$$PGCONF"
 
+      PGCONF="$$PGDATA/postgresql.conf"
+
+      echo "Initializing required spock configuration parameters in postgresql.conf"
+
+      # Allow connections from any address (for demo purposes)
+      echo "listen_addresses = '*'"              >> "$$PGCONF"
+
+      # Enable logical replication
+      echo "wal_level = 'logical'"                     >> "$$PGCONF"
+      echo "max_worker_processes = 10"                 >> "$$PGCONF"
+      echo "max_replication_slots = 10"                >> "$$PGCONF"
+      echo "max_wal_senders = 10"                      >> "$$PGCONF"
+      echo "track_commit_timestamp = 'on'"             >> "$$PGCONF"
+
+      # Set Spock parameters
+      echo "spock.enable_ddl_replication = 'on'"            >> "$$PGCONF"
+      echo "spock.include_ddl_repset = 'on'"                >> "$$PGCONF"
+      echo "spock.allow_ddl_from_functions = 'on'"          >> "$$PGCONF"
+      echo "spock.conflict_resolution = 'last_update_wins'" >> "$$PGCONF"
+      echo "spock.save_resolutions = 'on'"                  >> "$$PGCONF"
+      echo "spock.conflict_log_level = 'DEBUG'"             >> "$$PGCONF"
   restart-postgres:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
-      echo "Mid-sequence restart to apply base configuration..."
-      pg_ctl -D "$$PGDATA" -m fast restart
 
+      echo "Restarting PostgreSQL to apply configuration changes..."
+      pg_ctl -D "$$PGDATA" -m fast restart
   create-extensions:
     content: |-
       #!/usr/bin/env bash
       set -Eeo pipefail
-      EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "postgis")
+
+      EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "vector" "postgis")
+
       echo "Initializing extensions: $${EXTENSIONS[*]}"
       for EXT in "$${EXTENSIONS[@]}"; do
         echo "Creating extension: $$EXT"
-        psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" \
-          -c "CREATE EXTENSION IF NOT EXISTS \"$$EXT\";"
+        psql -v ON_ERROR_STOP=1 --username "$$POSTGRES_USER" --dbname "$$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS \"$$EXT\";"
       done
-
   relax-pg-hba:
     content: |-
       #!/usr/bin/env bash
@@ -163,7 +174,6 @@ configs:
       echo "host all all 0.0.0.0/0 md5" >> "$$PGDATA/pg_hba.conf"
       echo "host all all ::/0 md5"     >> "$$PGDATA/pg_hba.conf"
       pg_ctl -D "$$PGDATA" -m fast reload
-
   # Per-node setup: also ensures the pgedge role exists; node_create uses pgedge in DSN.
   spock-node:
     content: |-
@@ -213,7 +223,6 @@ configs:
       else
         echo "[spock-node] node '$${NODE_NAME}' already present; skipping."
       fi
-
   # Wiring script: admin executes sub_create; provider_dsn uses replication user.
   spock-wire-script:
     content: |-

--- a/examples/compose/enterprise/README.md
+++ b/examples/compose/enterprise/README.md
@@ -1,0 +1,118 @@
+# pgEdge Enterprise Postgres — Quick Start
+
+This example spins up a single pgEdge Enterprise Postgres container with additional enterprise extensions enabled (pgAudit, PostGIS, Snowflake, Spock, etc.). The container is configured with logical replication support and initializes all extensions automatically at startup.
+
+## Prerequisites
+
+- Docker & Docker Compose installed
+
+- Port 6432 available on your host machine
+
+- Internet access to pull container images
+
+### Using this Docker File
+
+The docker-compose.yaml file in this repository creates a Postgres database named example_db with enterprise extensions pre-loaded. Before running this file, ensure that you have Docker installed and running.
+
+To deploy this example, run:
+
+```sh
+docker compose up -d
+```
+
+This will build and start the pgEdge Enterprise Postgres service.
+
+Connecting to example_db with psql
+
+docker compose exec pgedge-postgres psql -U admin example_db
+
+### Enterprise Extensions
+
+This enterprise image automatically enables and installs the following extensions:
+
+- pg_stat_statements
+
+- pgAudit
+
+- Snowflake
+
+- Spock
+
+- PostGIS
+
+These are configured in two phases:
+
+The init-extensions and configure-spock scripts update postgresql.conf with preload libraries and Spock settings.
+
+The create-extensions script runs CREATE EXTENSION commands to load them into your database.
+
+You can confirm extensions are installed by running:
+```sh
+\dx
+```
+inside your psql session.
+
+### Restarting PostgreSQL During Init
+
+To apply configuration changes, the initialization sequence includes a controlled restart of PostgreSQL:
+```sh
+pg_ctl -D $PGDATA -m fast restart
+```
+
+This happens automatically during first startup. You don’t need to run this manually unless you change configuration.
+
+### Loading Sample Data
+
+You can load the Northwind sample dataset into your enterprise Postgres instance by running:
+```sh
+curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T pgedge-postgres psql -U admin example_db
+```
+
+Once loaded, verify with a query such as:
+```sh
+docker compose exec pgedge-postgres psql -U admin example_db -c "select * from northwind.shippers;"
+```
+Connecting from Outside the Container
+
+If you have psql, pgAdmin, or another Postgres client installed on your host machine, use this connection string:
+
+host=localhost port=6432 user=admin password=password dbname=example_db
+
+
+For example, with psql:
+
+psql 'host=localhost port=6432 user=admin password=password dbname=example_db'
+
+Modifying this Example
+
+You can adjust environment variables in docker-compose.yaml to change default credentials and database name:
+
+environment:
+-  POSTGRES_USER: admin
+-  POSTGRES_PASSWORD: password
+-  POSTGRES_DB: example_db
+
+POSTGRES_USER: database superuser (default: admin).
+
+POSTGRES_PASSWORD: password for the superuser (default: password).
+
+POSTGRES_DB: database name (default: example_db).
+
+The published port can also be changed:
+
+ports:
+  - target: 5432
+    published: 6432
+
+
+Change 6432 if you need to run multiple Postgres services on the same host.
+
+Recreating with a Fresh Configuration
+
+This setup only applies during initial container creation. If you want to restart with a fresh database:
+```sh
+docker compose down -v
+docker compose up -d
+```
+
+The -v flag ensures volumes are removed so configuration and extension initialization re-runs.

--- a/examples/compose/enterprise/README.md
+++ b/examples/compose/enterprise/README.md
@@ -107,7 +107,7 @@ ports:
 
 Change 6432 if you need to run multiple Postgres services on the same host.
 
-Recreating with a Fresh Configuration
+## Recreating with a Fresh Configuration
 
 This setup only applies during initial container creation. If you want to restart with a fresh database:
 ```sh

--- a/examples/compose/enterprise/README.md
+++ b/examples/compose/enterprise/README.md
@@ -72,7 +72,7 @@ Once loaded, verify with a query such as:
 ```sh
 docker compose exec pgedge-postgres psql -U admin example_db -c "select * from northwind.shippers;"
 ```
-Connecting from Outside the Container
+## Connecting from Outside the Container
 
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, use this connection string:
 
@@ -83,7 +83,7 @@ For example, with psql:
 
 psql 'host=localhost port=6432 user=admin password=password dbname=example_db'
 
-Modifying this Example
+## Modifying this Example
 
 You can adjust environment variables in docker-compose.yaml to change default credentials and database name:
 

--- a/examples/compose/enterprise/README.md
+++ b/examples/compose/enterprise/README.md
@@ -4,11 +4,9 @@ This example spins up a single pgEdge Enterprise Postgres container with additio
 
 ## Prerequisites
 
-- Docker & Docker Compose installed
-
-- Port 6432 available on your host machine
-
-- Internet access to pull container images
+- Install Docker and Docker Compose on your host system.
+- Ensure that port 6432 is available on your host system.
+- Ensure that the host system has internet access to pull container images.
 
 ### Using this Docker File
 
@@ -22,22 +20,20 @@ docker compose up -d
 
 This will build and start the pgEdge Enterprise Postgres service.
 
-Connecting to example_db with psql
+#### Connecting to example_db with psql
 
+```shell
 docker compose exec pgedge-postgres psql -U admin example_db
+```
 
 ### Enterprise Extensions
 
 This enterprise image automatically enables and installs the following extensions:
 
 - pg_stat_statements
-
 - pgAudit
-
 - Snowflake
-
 - Spock
-
 - PostGIS
 
 These are configured in two phases:
@@ -63,7 +59,7 @@ This happens automatically during first startup. You don’t need to run this ma
 
 ### Loading Sample Data
 
-You can load the Northwind sample dataset into your enterprise Postgres instance by running:
+You can load the Northwind sample dataset into your Postgres database by running:
 ```sh
 curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T pgedge-postgres psql -U admin example_db
 ```
@@ -107,7 +103,7 @@ ports:
 
 Change 6432 if you need to run multiple Postgres services on the same host.
 
-## Recreating with a Fresh Configuration
+## Recreating the container
 
 This setup only applies during initial container creation. If you want to restart with a fresh database:
 ```sh

--- a/examples/compose/enterprise/README.md
+++ b/examples/compose/enterprise/README.md
@@ -34,6 +34,7 @@ This enterprise image automatically enables and installs the following extension
 - pgAudit
 - Snowflake
 - Spock
+- pgVector
 - PostGIS
 
 These are configured in two phases:
@@ -91,21 +92,19 @@ You can adjust environment variables in docker-compose.yaml to change default cr
 environment:
 
 - POSTGRES_USER: admin
+  - database superuser (default: admin).
 - POSTGRES_PASSWORD: password
+  - password for the superuser (default: password).
 - POSTGRES_DB: example_db
-
-POSTGRES_USER: database superuser (default: admin).
-
-POSTGRES_PASSWORD: password for the superuser (default: password).
-
-POSTGRES_DB: database name (default: example_db).
+  - database name (default: example_db).
 
 The published port can also be changed:
 
-ports:
-
-- target: 5432
-  published: 6432
+```yaml
+    ports:
+      - target: 5432
+        published: 6432
+```
 
 Change 6432 if you need to run multiple Postgres services on the same host.
 

--- a/examples/compose/enterprise/README.md
+++ b/examples/compose/enterprise/README.md
@@ -1,4 +1,4 @@
-# pgEdge Enterprise Postgres — Quick Start
+# pgEdge Enterprise Postgres - Docker Compose Example
 
 This example spins up a single pgEdge Enterprise Postgres container with additional enterprise extensions enabled (pgAudit, PostGIS, Snowflake, Spock, etc.). The container is configured with logical replication support and initializes all extensions automatically at startup.
 
@@ -43,14 +43,17 @@ The init-extensions and configure-spock scripts update postgresql.conf with prel
 The create-extensions script runs CREATE EXTENSION commands to load them into your database.
 
 You can confirm extensions are installed by running:
+
 ```sh
 \dx
 ```
+
 inside your psql session.
 
 ### Restarting PostgreSQL During Init
 
 To apply configuration changes, the initialization sequence includes a controlled restart of PostgreSQL:
+
 ```sh
 pg_ctl -D $PGDATA -m fast restart
 ```
@@ -60,33 +63,36 @@ This happens automatically during first startup. You don’t need to run this ma
 ### Loading Sample Data
 
 You can load the Northwind sample dataset into your Postgres database by running:
+
 ```sh
 curl https://downloads.pgedge.com/platform/examples/northwind/northwind.sql | docker compose exec -T pgedge-postgres psql -U admin example_db
 ```
 
 Once loaded, verify with a query such as:
+
 ```sh
 docker compose exec pgedge-postgres psql -U admin example_db -c "select * from northwind.shippers;"
 ```
+
 ## Connecting from Outside the Container
 
 If you have psql, pgAdmin, or another Postgres client installed on your host machine, use this connection string:
 
-host=localhost port=6432 user=admin password=password dbname=example_db
-
+`host=localhost port=6432 user=admin password=password dbname=example_db`
 
 For example, with psql:
 
-psql 'host=localhost port=6432 user=admin password=password dbname=example_db'
+`psql 'host=localhost port=6432 user=admin password=password dbname=example_db'`
 
 ## Modifying this Example
 
 You can adjust environment variables in docker-compose.yaml to change default credentials and database name:
 
 environment:
--  POSTGRES_USER: admin
--  POSTGRES_PASSWORD: password
--  POSTGRES_DB: example_db
+
+- POSTGRES_USER: admin
+- POSTGRES_PASSWORD: password
+- POSTGRES_DB: example_db
 
 POSTGRES_USER: database superuser (default: admin).
 
@@ -97,15 +103,16 @@ POSTGRES_DB: database name (default: example_db).
 The published port can also be changed:
 
 ports:
-  - target: 5432
-    published: 6432
 
+- target: 5432
+  published: 6432
 
 Change 6432 if you need to run multiple Postgres services on the same host.
 
 ## Recreating the container
 
 This setup only applies during initial container creation. If you want to restart with a fresh database:
+
 ```sh
 docker compose down -v
 docker compose up -d

--- a/examples/compose/enterprise/docker-compose.yaml
+++ b/examples/compose/enterprise/docker-compose.yaml
@@ -52,6 +52,9 @@ configs:
 
       echo "Initializing required spock configuration parameters in postgresql.conf"
 
+      # Allow connections from any address (for demo purposes)
+      echo "listen_addresses = '*'"              >> "$$PGCONF"
+      
       # Enable logical replication
       echo "wal_level = 'logical'"                     >> "$$PGCONF"
       echo "max_worker_processes = 10"                 >> "$$PGCONF"
@@ -78,7 +81,7 @@ configs:
       #!/usr/bin/env bash
       set -Eeo pipefail
 
-      EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "postgis")
+      EXTENSIONS=("pg_stat_statements" "pgaudit" "snowflake" "spock" "vector" "postgis")
 
       echo "Initializing extensions: $${EXTENSIONS[*]}"
       for EXT in "$${EXTENSIONS[@]}"; do


### PR DESCRIPTION
feat(compose): two-node Postgres 17 + Spock 5 with auto wiring & health-gated init

This commit adds a production-like, fully automated Docker Compose setup that
brings up two PostgreSQL 17 nodes with Spock 5 logical replication and wires
bi-directional subscriptions only after both nodes are healthy. It also adds
idempotent init scripts, permissive demo networking, and a short-lived wiring
job that guarantees order and readiness.

## What’s included
- Services:
  - `postgres-n1` (host port 6432 → 5432) and `postgres-n2` (host port 6433 → 5432)
    * DB: `acctg`, user: `pgedge/pgedge` (override via env)
    * Healthchecks gating dependent work: `pg_isready` on DB/user
  - `spock-wire` (ephemeral job)
    * Waits for both nodes to be ready, then creates cross-node subscriptions

- Init sequence per node (config-driven via `configs:`):
  1) `10-init-extensions.sh`
     - Sets `shared_preload_libraries` to: pg_stat_statements, pgaudit, snowflake, spock, postgis-3
  2) `20-configure-spock.sh`
     - Enables logical replication + Spock tuning:
       listen_addresses='*'
       wal_level=logical
       max_worker_processes/max_replication_slots/max_wal_senders=10
       track_commit_timestamp=on
       spock.*: enable_ddl_replication, include_ddl_repset, allow_ddl_from_functions,
                 conflict_resolution=last_update_wins, save_resolutions=on, conflict_log_level=DEBUG
  3) `30-restart-postgres.sh`
     - Fast restart to apply configs before extension creation
  4) `40-create-extensions.sh`
     - `CREATE EXTENSION IF NOT EXISTS` for: pg_stat_statements, pgaudit, snowflake, spock, postgis
  5) `45-relax-pg-hba.sh`
     - Appends IPv4/IPv6 md5 rules for demo access; reloads config
  6) `50-spock-nodes.sh` (node-specific)
     - Registers each instance as a Spock node via `spock.node_create(...)`
       * n1 → node 'n1' (dsn host=postgres-n1)
       * n2 → node 'n2' (dsn host=postgres-n2)

- Wiring job (`spock-wire`):
  - Blocks on both healthchecks with `pg_isready` (time-limited loops)
  - Idempotently ensures subscriptions exist:
    * On n1: `sub_n1n2` (provider DSN → postgres-n2:5432)
    * On n2: `sub_n2n1` (provider DSN → postgres-n1:5432)
  - Uses DO blocks checking `spock.subscription` to avoid duplicates
  - Exits after success; subscriptions remain active

## How to run
- `docker compose up -d`
- Connect from host:
  - n1: `psql -h localhost -p 6432 -U pgedge -d acctg`
  - n2: `psql -h localhost -p 6433 -U pgedge -d acctg`

## Quick verification
- Create a table + insert on n1, read on n2; then insert on n2, read on n1.
- Inspect:
  - `SELECT * FROM spock.node;`
  - `SELECT * FROM spock.subscription;`
  - `SELECT * FROM spock.sub_show_status('sub_n1n2');`
  - `SELECT * FROM spock.sub_show_status('sub_n2n1');`

## Rationale
- Health-gated init prevents race conditions in node registration and subscription wiring.
- Idempotent DO blocks enable repeatable, resilient bootstraps and fast rebuilds.

Docs: README added with overview, usage, tests, and troubleshooting.

Jira ticket:[PLAT-277](https://pgedge.atlassian.net/browse/PLAT-277?atlOrigin=eyJpIjoiMWQ2MWVmMjA4NDQxNGZiODljNWVlYTE3NGU0ZWE0NDkiLCJwIjoiaiJ9)


[PLAT-277]: https://pgedge.atlassian.net/browse/PLAT-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ