### PR TITLE
feat: update examples to use pg18 by default

### DIFF
--- a/examples/compose/distributed/docker-compose.yaml
+++ b/examples/compose/distributed/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   postgres-n1:
-    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
+    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:18-spock5-standard}
+    pull_policy: always
     container_name: postgres-n1
     restart: always
     environment:
@@ -42,7 +43,8 @@ services:
         mode: 0755
 
   postgres-n2:
-    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
+    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:18-spock5-standard}
+    pull_policy: always
     container_name: postgres-n2
     restart: always
     environment:

--- a/examples/compose/enterprise/docker-compose.yaml
+++ b/examples/compose/enterprise/docker-compose.yaml
@@ -1,7 +1,8 @@
 
 services:
   pgedge-postgres:
-    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:17-spock5-standard}
+    image: ${POSTGRES_IMAGE:-ghcr.io/pgedge/pgedge-postgres:18-spock5-standard}
+    pull_policy: always
     restart: always
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-admin}


### PR DESCRIPTION
Additionally, set `pull_policy` to `always` since we are using mutable image tags.