### PR TITLE
Add system_stats extension test

### DIFF
--- a/tests/main.go
+++ b/tests/main.go
@@ -709,6 +709,26 @@ func getCommonExtensionTests() []Test {
 func getStandardOnlyTests() []Test {
 	return []Test{
 		{
+			Name:           "system_stats extension can be created",
+			StandardOnly:   true,
+			Cmd:            "psql -U postgres -d testdb -t -A -c \"CREATE EXTENSION IF NOT EXISTS system_stats; SELECT 1;\"",
+			ExpectedOutput: expectSuccess,
+		},
+		{
+			Name:         "system_stats pg_sys_os_info works",
+			StandardOnly: true,
+			Cmd:          "psql -U postgres -d testdb -t -A -c \"SELECT 1 FROM pg_sys_os_info();\"",
+			ExpectedOutput: func(exitCode int, output string) error {
+				if exitCode != 0 {
+					return fmt.Errorf("unexpected exit code: %d", exitCode)
+				}
+				if strings.TrimSpace(output) != "1" {
+					return fmt.Errorf("unexpected output: %s (expected 1)", output)
+				}
+				return nil
+			},
+		},
+		{
 			Name:           "pgvector extension can be created",
 			StandardOnly:   true,
 			Cmd:            "psql -U postgres -d testdb -t -A -c \"CREATE EXTENSION IF NOT EXISTS vector; SELECT 1;\"",


### PR DESCRIPTION
1. Add standard-only tests to create system_stats and validate pg_sys_os_info() returns a row.
2. Keep system_stats tests out of minimal images because the extension is only packaged in standard images; minimal would fail by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for system_stats extension creation and validation
  * Added test coverage for OS information retrieval functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->