### PR TITLE
fix: revert spock 5.0.7 image change to unpublish

### DIFF
--- a/packagelists/amd64/pg16.13-spock5.0.6-minimal.txt
+++ b/packagelists/amd64/pg16.13-spock5.0.6-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql16-16.13-1.el9
-pgedge-spock50_16-5.0.7-1.el9
+pgedge-spock50_16-5.0.6-1.el9
 pgedge-snowflake_16-2.4-1.el9
 pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/amd64/pg16.13-spock5.0.6-standard.txt
+++ b/packagelists/amd64/pg16.13-spock5.0.6-standard.txt
@@ -1,5 +1,5 @@
 pgedge-postgresql16-16.13-1.el9
-pgedge-spock50_16-5.0.7-1.el9
+pgedge-spock50_16-5.0.6-1.el9
 pgedge-snowflake_16-2.4-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9

--- a/packagelists/amd64/pg17.9-spock5.0.6-minimal.txt
+++ b/packagelists/amd64/pg17.9-spock5.0.6-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql17-17.9-1.el9
-pgedge-spock50_17-5.0.7-1.el9
+pgedge-spock50_17-5.0.6-1.el9
 pgedge-snowflake_17-2.4-1.el9
 pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/amd64/pg17.9-spock5.0.6-standard.txt
+++ b/packagelists/amd64/pg17.9-spock5.0.6-standard.txt
@@ -1,5 +1,5 @@
 pgedge-postgresql17-17.9-1.el9
-pgedge-spock50_17-5.0.7-1.el9
+pgedge-spock50_17-5.0.6-1.el9
 pgedge-snowflake_17-2.4-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9

--- a/packagelists/amd64/pg18.3-spock5.0.6-minimal.txt
+++ b/packagelists/amd64/pg18.3-spock5.0.6-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql18-18.3-1.el9
-pgedge-spock50_18-5.0.7-1.el9
+pgedge-spock50_18-5.0.6-1.el9
 pgedge-snowflake_18-2.4-1.el9
 pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/amd64/pg18.3-spock5.0.6-standard.txt
+++ b/packagelists/amd64/pg18.3-spock5.0.6-standard.txt
@@ -1,5 +1,5 @@
 pgedge-postgresql18-18.3-1.el9
-pgedge-spock50_18-5.0.7-1.el9
+pgedge-spock50_18-5.0.6-1.el9
 pgedge-snowflake_18-2.4-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9

--- a/packagelists/arm64/pg16.13-spock5.0.6-minimal.txt
+++ b/packagelists/arm64/pg16.13-spock5.0.6-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql16-16.13-1.el9
-pgedge-spock50_16-5.0.7-1.el9
+pgedge-spock50_16-5.0.6-1.el9
 pgedge-snowflake_16-2.4-1.el9
 pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/arm64/pg16.13-spock5.0.6-standard.txt
+++ b/packagelists/arm64/pg16.13-spock5.0.6-standard.txt
@@ -1,5 +1,5 @@
 pgedge-postgresql16-16.13-1.el9
-pgedge-spock50_16-5.0.7-1.el9
+pgedge-spock50_16-5.0.6-1.el9
 pgedge-snowflake_16-2.4-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9

--- a/packagelists/arm64/pg17.9-spock5.0.6-minimal.txt
+++ b/packagelists/arm64/pg17.9-spock5.0.6-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql17-17.9-1.el9
-pgedge-spock50_17-5.0.7-1.el9
+pgedge-spock50_17-5.0.6-1.el9
 pgedge-snowflake_17-2.4-1.el9
 pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/arm64/pg17.9-spock5.0.6-standard.txt
+++ b/packagelists/arm64/pg17.9-spock5.0.6-standard.txt
@@ -1,5 +1,5 @@
 pgedge-postgresql17-17.9-1.el9
-pgedge-spock50_17-5.0.7-1.el9
+pgedge-spock50_17-5.0.6-1.el9
 pgedge-snowflake_17-2.4-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9

--- a/packagelists/arm64/pg18.3-spock5.0.6-minimal.txt
+++ b/packagelists/arm64/pg18.3-spock5.0.6-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql18-18.3-1.el9
-pgedge-spock50_18-5.0.7-1.el9
+pgedge-spock50_18-5.0.6-1.el9
 pgedge-snowflake_18-2.4-1.el9
 pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/arm64/pg18.3-spock5.0.6-standard.txt
+++ b/packagelists/arm64/pg18.3-spock5.0.6-standard.txt
@@ -1,5 +1,5 @@
 pgedge-postgresql18-18.3-1.el9
-pgedge-spock50_18-5.0.7-1.el9
+pgedge-spock50_18-5.0.6-1.el9
 pgedge-snowflake_18-2.4-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9

--- a/scripts/build_pgedge_images.py
+++ b/scripts/build_pgedge_images.py
@@ -162,24 +162,24 @@ all_images: list[PgEdgeImage] = [
     # pg16 images
     *make_all_flavor_images(
         postgres_version="16.13",
-        spock_version="5.0.7",
-        epoch=1,
+        spock_version="5.0.6",
+        epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
     ),
     # pg17 images
     *make_all_flavor_images(
         postgres_version="17.9",
-        spock_version="5.0.7",
-        epoch=1,
+        spock_version="5.0.6",
+        epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
     ),
     # pg18 images
     *make_all_flavor_images(
         postgres_version="18.3",
-        spock_version="5.0.7",
-        epoch=1,
+        spock_version="5.0.6",
+        epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
     ),


### PR DESCRIPTION
## Summary

Reverts PR #19 (spock 5.0.7 update) to move the mutable image tags back to spock 5.0.6 variants. Restores the script's `spock_version` to `5.0.6` / `epoch=2` across pg16/17/18 and renames the packagelists back to `pg*-spock5.0.6-*.txt`.

The 5.0.6 immutable tags (`*-spock5.0.6-{minimal,standard}-2`) still exist in the registry, so the `build-images` workflow will skip the build step and only re-point the mutable tags (`*-spock5*-*`, `*-spock5.0.6-*`) at the existing 5.0.6 manifests via `docker buildx imagetools create`.

5.0.7 immutable tags will be deleted manually in the GHCR UI after merge.

## Test plan

Run the `build-images` workflow against the internal repo before merging:

- [x] Dry run on internal: Actions → `build-images` → Run workflow on this branch with:
  - `pgedge_image_repo`: `ghcr.io/pgedge/pgedge-postgres-internal` (default)
  - `pgedge_image_dry_run`: `true`
  - `pgedge_image_republish`: `false`
  - Confirm the log shows `<tag> is already published` for each `*-spock5.0.6-*-2` build tag and `adding new tag ... to existing manifest` for each mutable tag — no `building and pushing images` lines.
- [x] Live run on internal: same inputs, `pgedge_image_dry_run`: `false`. Verify on `ghcr.io/pgedge/pgedge-postgres-internal` that `17-spock5-standard`, `17.9-spock5-standard`, `17.9-spock5.0.6-standard` (and the pg16/pg18 equivalents, both flavors) resolve to the 5.0.6 manifest digest.
- [ ] After merge to `main`, run the same workflow against `ghcr.io/pgedge/pgedge-postgres` (production repo) with `dry_run: true` first, then live.
- [ ] Manually delete `*-spock5.0.7-*` versions from the production package in the GHCR UI.
