### PR TITLE
Update spock to 5.0.11, snowflake to 2.6.0, postgis to 3.5.7

### DIFF
--- a/packagelists/amd64/pg16.14-spock5.0.10-minimal.txt
+++ b/packagelists/amd64/pg16.14-spock5.0.10-minimal.txt
@@ -1,4 +1,0 @@
-pgedge-postgresql16-16.14-2.el9
-pgedge-spock50_16-5.0.10-1.el9
-pgedge-snowflake_16-2.5.0-1.el9
-pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/amd64/pg16.14-spock5.0.11-minimal.txt
+++ b/packagelists/amd64/pg16.14-spock5.0.11-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql16-16.14-2.el9
-pgedge-spock60_16-6.0.0-beta1_1.el9
+pgedge-spock50_16-5.0.11-1.el9
 pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/amd64/pg16.14-spock5.0.11-standard.txt
+++ b/packagelists/amd64/pg16.14-spock5.0.11-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql16-16.14-2.el9
-pgedge-spock50_16-5.0.10-1.el9
-pgedge-snowflake_16-2.5.0-1.el9
+pgedge-spock50_16-5.0.11-1.el9
+pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
-pgedge-postgis35_16-3.5.5-1.el9
+pgedge-postgis35_16-3.5.7-1.el9
 pgedge-pgvector_16-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/amd64/pg16.14-spock5.0.11-standard.txt
+++ b/packagelists/amd64/pg16.14-spock5.0.11-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
 pgedge-postgis35_16-3.5.7-1.el9
-pgedge-pgvector_16-0.8.1-1.el9
+pgedge-pgvector_16-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_16-1.8.0-1.el9

--- a/packagelists/amd64/pg16.14-spock6.0.0-beta1-standard.txt
+++ b/packagelists/amd64/pg16.14-spock6.0.0-beta1-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql16-16.14-2.el9
 pgedge-spock60_16-6.0.0-beta1_1.el9
-pgedge-snowflake_16-2.5.0-1.el9
+pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
-pgedge-postgis35_16-3.5.5-1.el9
+pgedge-postgis35_16-3.5.7-1.el9
 pgedge-pgvector_16-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/amd64/pg16.14-spock6.0.0-beta1-standard.txt
+++ b/packagelists/amd64/pg16.14-spock6.0.0-beta1-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
 pgedge-postgis35_16-3.5.7-1.el9
-pgedge-pgvector_16-0.8.1-1.el9
+pgedge-pgvector_16-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_16-1.8.0-1.el9

--- a/packagelists/amd64/pg17.10-spock5.0.10-minimal.txt
+++ b/packagelists/amd64/pg17.10-spock5.0.10-minimal.txt
@@ -1,4 +1,0 @@
-pgedge-postgresql17-17.10-2.el9
-pgedge-spock50_17-5.0.10-1.el9
-pgedge-snowflake_17-2.5.0-1.el9
-pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/amd64/pg17.10-spock5.0.11-minimal.txt
+++ b/packagelists/amd64/pg17.10-spock5.0.11-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql17-17.10-2.el9
-pgedge-spock60_17-6.0.0-beta1_1.el9
+pgedge-spock50_17-5.0.11-1.el9
 pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/amd64/pg17.10-spock5.0.11-standard.txt
+++ b/packagelists/amd64/pg17.10-spock5.0.11-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql17-17.10-2.el9
-pgedge-spock50_17-5.0.10-1.el9
-pgedge-snowflake_17-2.5.0-1.el9
+pgedge-spock50_17-5.0.11-1.el9
+pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
-pgedge-postgis35_17-3.5.5-1.el9
+pgedge-postgis35_17-3.5.7-1.el9
 pgedge-pgvector_17-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/amd64/pg17.10-spock5.0.11-standard.txt
+++ b/packagelists/amd64/pg17.10-spock5.0.11-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
 pgedge-postgis35_17-3.5.7-1.el9
-pgedge-pgvector_17-0.8.1-1.el9
+pgedge-pgvector_17-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_17-1.8.0-1.el9

--- a/packagelists/amd64/pg17.10-spock6.0.0-beta1-standard.txt
+++ b/packagelists/amd64/pg17.10-spock6.0.0-beta1-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql17-17.10-2.el9
 pgedge-spock60_17-6.0.0-beta1_1.el9
-pgedge-snowflake_17-2.5.0-1.el9
+pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
-pgedge-postgis35_17-3.5.5-1.el9
+pgedge-postgis35_17-3.5.7-1.el9
 pgedge-pgvector_17-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/amd64/pg17.10-spock6.0.0-beta1-standard.txt
+++ b/packagelists/amd64/pg17.10-spock6.0.0-beta1-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
 pgedge-postgis35_17-3.5.7-1.el9
-pgedge-pgvector_17-0.8.1-1.el9
+pgedge-pgvector_17-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_17-1.8.0-1.el9

--- a/packagelists/amd64/pg18.4-spock5.0.10-minimal.txt
+++ b/packagelists/amd64/pg18.4-spock5.0.10-minimal.txt
@@ -1,4 +1,0 @@
-pgedge-postgresql18-18.4-2.el9
-pgedge-spock50_18-5.0.10-1.el9
-pgedge-snowflake_18-2.5.0-1.el9
-pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/amd64/pg18.4-spock5.0.11-minimal.txt
+++ b/packagelists/amd64/pg18.4-spock5.0.11-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql18-18.4-2.el9
-pgedge-spock60_18-6.0.0-beta1_1.el9
+pgedge-spock50_18-5.0.11-1.el9
 pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/amd64/pg18.4-spock5.0.11-standard.txt
+++ b/packagelists/amd64/pg18.4-spock5.0.11-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
 pgedge-postgis35_18-3.5.7-1.el9
-pgedge-pgvector_18-0.8.1-1.el9
+pgedge-pgvector_18-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_18-1.8.0-1.el9

--- a/packagelists/amd64/pg18.4-spock5.0.11-standard.txt
+++ b/packagelists/amd64/pg18.4-spock5.0.11-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql18-18.4-2.el9
-pgedge-spock50_18-5.0.10-1.el9
-pgedge-snowflake_18-2.5.0-1.el9
+pgedge-spock50_18-5.0.11-1.el9
+pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
-pgedge-postgis35_18-3.5.5-1.el9
+pgedge-postgis35_18-3.5.7-1.el9
 pgedge-pgvector_18-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/amd64/pg18.4-spock6.0.0-beta1-standard.txt
+++ b/packagelists/amd64/pg18.4-spock6.0.0-beta1-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
 pgedge-postgis35_18-3.5.7-1.el9
-pgedge-pgvector_18-0.8.1-1.el9
+pgedge-pgvector_18-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_18-1.8.0-1.el9

--- a/packagelists/amd64/pg18.4-spock6.0.0-beta1-standard.txt
+++ b/packagelists/amd64/pg18.4-spock6.0.0-beta1-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql18-18.4-2.el9
 pgedge-spock60_18-6.0.0-beta1_1.el9
-pgedge-snowflake_18-2.5.0-1.el9
+pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
-pgedge-postgis35_18-3.5.5-1.el9
+pgedge-postgis35_18-3.5.7-1.el9
 pgedge-pgvector_18-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/arm64/pg16.14-spock5.0.10-minimal.txt
+++ b/packagelists/arm64/pg16.14-spock5.0.10-minimal.txt
@@ -1,4 +1,0 @@
-pgedge-postgresql16-16.14-2.el9
-pgedge-spock50_16-5.0.10-1.el9
-pgedge-snowflake_16-2.5.0-1.el9
-pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/arm64/pg16.14-spock5.0.11-minimal.txt
+++ b/packagelists/arm64/pg16.14-spock5.0.11-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql16-16.14-2.el9
-pgedge-spock60_16-6.0.0-beta1_1.el9
+pgedge-spock50_16-5.0.11-1.el9
 pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/arm64/pg16.14-spock5.0.11-standard.txt
+++ b/packagelists/arm64/pg16.14-spock5.0.11-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql16-16.14-2.el9
-pgedge-spock50_16-5.0.10-1.el9
-pgedge-snowflake_16-2.5.0-1.el9
+pgedge-spock50_16-5.0.11-1.el9
+pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
-pgedge-postgis35_16-3.5.5-1.el9
+pgedge-postgis35_16-3.5.7-1.el9
 pgedge-pgvector_16-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/arm64/pg16.14-spock5.0.11-standard.txt
+++ b/packagelists/arm64/pg16.14-spock5.0.11-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
 pgedge-postgis35_16-3.5.7-1.el9
-pgedge-pgvector_16-0.8.1-1.el9
+pgedge-pgvector_16-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_16-1.8.0-1.el9

--- a/packagelists/arm64/pg16.14-spock6.0.0-beta1-minimal.txt
+++ b/packagelists/arm64/pg16.14-spock6.0.0-beta1-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql16-16.14-2.el9
 pgedge-spock60_16-6.0.0-beta1_1.el9
-pgedge-snowflake_16-2.5.0-1.el9
+pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9

--- a/packagelists/arm64/pg16.14-spock6.0.0-beta1-standard.txt
+++ b/packagelists/arm64/pg16.14-spock6.0.0-beta1-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql16-16.14-2.el9
 pgedge-spock60_16-6.0.0-beta1_1.el9
-pgedge-snowflake_16-2.5.0-1.el9
+pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
-pgedge-postgis35_16-3.5.5-1.el9
+pgedge-postgis35_16-3.5.7-1.el9
 pgedge-pgvector_16-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/arm64/pg16.14-spock6.0.0-beta1-standard.txt
+++ b/packagelists/arm64/pg16.14-spock6.0.0-beta1-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_16-2.6.0-1.el9
 pgedge-lolor_16-1.2.2-1.el9
 pgedge-pgaudit_16-16.1-1.el9
 pgedge-postgis35_16-3.5.7-1.el9
-pgedge-pgvector_16-0.8.1-1.el9
+pgedge-pgvector_16-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_16-1.8.0-1.el9

--- a/packagelists/arm64/pg17.10-spock5.0.10-minimal.txt
+++ b/packagelists/arm64/pg17.10-spock5.0.10-minimal.txt
@@ -1,4 +1,0 @@
-pgedge-postgresql17-17.10-2.el9
-pgedge-spock50_17-5.0.10-1.el9
-pgedge-snowflake_17-2.5.0-1.el9
-pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/arm64/pg17.10-spock5.0.11-minimal.txt
+++ b/packagelists/arm64/pg17.10-spock5.0.11-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql17-17.10-2.el9
-pgedge-spock60_17-6.0.0-beta1_1.el9
+pgedge-spock50_17-5.0.11-1.el9
 pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/arm64/pg17.10-spock5.0.11-standard.txt
+++ b/packagelists/arm64/pg17.10-spock5.0.11-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql17-17.10-2.el9
-pgedge-spock50_17-5.0.10-1.el9
-pgedge-snowflake_17-2.5.0-1.el9
+pgedge-spock50_17-5.0.11-1.el9
+pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
-pgedge-postgis35_17-3.5.5-1.el9
+pgedge-postgis35_17-3.5.7-1.el9
 pgedge-pgvector_17-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/arm64/pg17.10-spock5.0.11-standard.txt
+++ b/packagelists/arm64/pg17.10-spock5.0.11-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
 pgedge-postgis35_17-3.5.7-1.el9
-pgedge-pgvector_17-0.8.1-1.el9
+pgedge-pgvector_17-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_17-1.8.0-1.el9

--- a/packagelists/arm64/pg17.10-spock6.0.0-beta1-minimal.txt
+++ b/packagelists/arm64/pg17.10-spock6.0.0-beta1-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql17-17.10-2.el9
 pgedge-spock60_17-6.0.0-beta1_1.el9
-pgedge-snowflake_17-2.5.0-1.el9
+pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9

--- a/packagelists/arm64/pg17.10-spock6.0.0-beta1-standard.txt
+++ b/packagelists/arm64/pg17.10-spock6.0.0-beta1-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql17-17.10-2.el9
 pgedge-spock60_17-6.0.0-beta1_1.el9
-pgedge-snowflake_17-2.5.0-1.el9
+pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
-pgedge-postgis35_17-3.5.5-1.el9
+pgedge-postgis35_17-3.5.7-1.el9
 pgedge-pgvector_17-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/arm64/pg17.10-spock6.0.0-beta1-standard.txt
+++ b/packagelists/arm64/pg17.10-spock6.0.0-beta1-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_17-2.6.0-1.el9
 pgedge-lolor_17-1.2.2-1.el9
 pgedge-pgaudit_17-17.1-1.el9
 pgedge-postgis35_17-3.5.7-1.el9
-pgedge-pgvector_17-0.8.1-1.el9
+pgedge-pgvector_17-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_17-1.8.0-1.el9

--- a/packagelists/arm64/pg18.4-spock5.0.10-minimal.txt
+++ b/packagelists/arm64/pg18.4-spock5.0.10-minimal.txt
@@ -1,4 +1,0 @@
-pgedge-postgresql18-18.4-2.el9
-pgedge-spock50_18-5.0.10-1.el9
-pgedge-snowflake_18-2.5.0-1.el9
-pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/arm64/pg18.4-spock5.0.11-minimal.txt
+++ b/packagelists/arm64/pg18.4-spock5.0.11-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql18-18.4-2.el9
-pgedge-spock60_18-6.0.0-beta1_1.el9
+pgedge-spock50_18-5.0.11-1.el9
 pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/arm64/pg18.4-spock5.0.11-standard.txt
+++ b/packagelists/arm64/pg18.4-spock5.0.11-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
 pgedge-postgis35_18-3.5.7-1.el9
-pgedge-pgvector_18-0.8.1-1.el9
+pgedge-pgvector_18-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_18-1.8.0-1.el9

--- a/packagelists/arm64/pg18.4-spock5.0.11-standard.txt
+++ b/packagelists/arm64/pg18.4-spock5.0.11-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql18-18.4-2.el9
-pgedge-spock50_18-5.0.10-1.el9
-pgedge-snowflake_18-2.5.0-1.el9
+pgedge-spock50_18-5.0.11-1.el9
+pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
-pgedge-postgis35_18-3.5.5-1.el9
+pgedge-postgis35_18-3.5.7-1.el9
 pgedge-pgvector_18-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/packagelists/arm64/pg18.4-spock6.0.0-beta1-minimal.txt
+++ b/packagelists/arm64/pg18.4-spock6.0.0-beta1-minimal.txt
@@ -1,4 +1,4 @@
 pgedge-postgresql18-18.4-2.el9
 pgedge-spock60_18-6.0.0-beta1_1.el9
-pgedge-snowflake_18-2.5.0-1.el9
+pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9

--- a/packagelists/arm64/pg18.4-spock6.0.0-beta1-standard.txt
+++ b/packagelists/arm64/pg18.4-spock6.0.0-beta1-standard.txt
@@ -4,7 +4,7 @@ pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
 pgedge-postgis35_18-3.5.7-1.el9
-pgedge-pgvector_18-0.8.1-1.el9
+pgedge-pgvector_18-0.8.5-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9
 pgedge-pgmq_18-1.8.0-1.el9

--- a/packagelists/arm64/pg18.4-spock6.0.0-beta1-standard.txt
+++ b/packagelists/arm64/pg18.4-spock6.0.0-beta1-standard.txt
@@ -1,9 +1,9 @@
 pgedge-postgresql18-18.4-2.el9
 pgedge-spock60_18-6.0.0-beta1_1.el9
-pgedge-snowflake_18-2.5.0-1.el9
+pgedge-snowflake_18-2.6.0-1.el9
 pgedge-lolor_18-1.2.2-1.el9
 pgedge-pgaudit_18-18.0-1.el9
-pgedge-postgis35_18-3.5.5-1.el9
+pgedge-postgis35_18-3.5.7-1.el9
 pgedge-pgvector_18-0.8.1-1.el9
 pgedge-pgbackrest-2.58.0-1.el9
 pgedge-python3-psycopg2-2.9.10-1.el9

--- a/scripts/build_pgedge_images.py
+++ b/scripts/build_pgedge_images.py
@@ -166,7 +166,6 @@ all_images: list[PgEdgeImage] = [
         epoch=1,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
-        package_release_channel="staging",
     ),
     # pg17 images
     *make_all_flavor_images(
@@ -175,7 +174,6 @@ all_images: list[PgEdgeImage] = [
         epoch=1,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
-        package_release_channel="staging",
     ),
     # pg18 images
     *make_all_flavor_images(
@@ -184,7 +182,6 @@ all_images: list[PgEdgeImage] = [
         epoch=1,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
-        package_release_channel="staging",
     ),
     # pg16 spock60 images
     *make_all_flavor_images(
@@ -193,7 +190,6 @@ all_images: list[PgEdgeImage] = [
         epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
-        package_release_channel="staging",
     ),
     # pg17 spock60 images
     *make_all_flavor_images(
@@ -202,7 +198,6 @@ all_images: list[PgEdgeImage] = [
         epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
-        package_release_channel="staging",
     ),
     # pg18 spock60 images
     *make_all_flavor_images(
@@ -211,7 +206,6 @@ all_images: list[PgEdgeImage] = [
         epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
-        package_release_channel="staging",
     ),
 ]
 

--- a/scripts/build_pgedge_images.py
+++ b/scripts/build_pgedge_images.py
@@ -162,50 +162,56 @@ all_images: list[PgEdgeImage] = [
     # pg16 images
     *make_all_flavor_images(
         postgres_version="16.14",
-        spock_version="5.0.10",
+        spock_version="5.0.11",
         epoch=1,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
+        package_release_channel="staging",
     ),
     # pg17 images
     *make_all_flavor_images(
         postgres_version="17.10",
-        spock_version="5.0.10",
+        spock_version="5.0.11",
         epoch=1,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
+        package_release_channel="staging",
     ),
     # pg18 images
     *make_all_flavor_images(
         postgres_version="18.4",
-        spock_version="5.0.10",
+        spock_version="5.0.11",
         epoch=1,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
+        package_release_channel="staging",
     ),
     # pg16 spock60 images
     *make_all_flavor_images(
         postgres_version="16.14",
         spock_version="6.0.0-beta1",
-        epoch=1,
+        epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
+        package_release_channel="staging",
     ),
     # pg17 spock60 images
     *make_all_flavor_images(
         postgres_version="17.10",
         spock_version="6.0.0-beta1",
-        epoch=1,
+        epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
+        package_release_channel="staging",
     ),
     # pg18 spock60 images
     *make_all_flavor_images(
         postgres_version="18.4",
         spock_version="6.0.0-beta1",
-        epoch=1,
+        epoch=2,
         is_latest_for_pg_major=True,
         is_latest_for_spock_major=True,
+        package_release_channel="staging",
     ),
 ]
 


### PR DESCRIPTION
Updates following components
- Spock to 5.0.11
- Snowflake to 2.6.0
- PostGIS to 3.5.7
- pgvector 0.8.5