### PR TITLE
resolve Trivy HIGH/MEDIUM CVEs via dnf update and patroni on python3.12

### DIFF
--- a/.trivy/pgedge-postgres.trivyignore.yaml
+++ b/.trivy/pgedge-postgres.trivyignore.yaml
@@ -1,0 +1,10 @@
+# Usage:
+#   trivy image --ignorefile .trivy/pgedge-postgres.trivyignore.yaml <pgedge-postgres image ref>
+#
+# Example entry:
+# vulnerabilities:
+#   - id: CVE-XXXX-YYYY
+#     statement: "Justification for accepting this risk"
+
+# No accepted-risk suppressions: all current findings are remediated in the Dockerfile.
+vulnerabilities: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,12 +118,13 @@ xargs dnf install -y < /usr/share/pgedge/packages.txt
 dnf update -y
 # Patroni's HTTP client dependencies only ship security fixes for Python >= 3.10
 # (urllib3 >= 2.7.0, requests >= 2.33.0), while the system python3 is 3.9. Install
-# patroni under python3.12 so it pulls the patched urllib3/requests, resolving
+# patroni under python3.12 so it can pull the patched urllib3/requests, resolving
 # CVE-2026-44431 and CVE-2026-44432 (urllib3) and CVE-2026-25645 (requests). The
-# psycopg3 extra bundles libpq, so patroni no longer relies on the Python
-# 3.9-only system psycopg2.
+# floors are pinned explicitly (patroni does not constrain them) so the build
+# fails loudly if a fixed version is ever unavailable. The psycopg3 extra bundles
+# libpq, so patroni no longer relies on the Python 3.9-only system psycopg2.
 dnf install -y python3.12 python3.12-pip
-python3.12 -m pip install 'patroni[etcd,jsonlogger,psycopg3]==4.1.3'
+python3.12 -m pip install 'patroni[etcd,jsonlogger,psycopg3]==4.1.3' 'urllib3>=2.7.0' 'requests>=2.33.0'
 dnf remove -y python3.12-pip
 dnf clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ set -o pipefail
 set -o nounset
 
 xargs dnf install -y < /usr/share/pgedge/packages.txt
+# Patch any OS packages (including transitive dependencies pulled in above)
+# to the latest available errata so the image ships with security fixes.
+dnf update -y
 dnf clean all
 
 EOF
@@ -110,9 +113,18 @@ set -o pipefail
 set -o nounset
 
 xargs dnf install -y < /usr/share/pgedge/packages.txt
-dnf install -y 'python3-pip-21.3.1-*'
-pip install 'patroni[etcd,jsonlogger]==4.1.3'
-dnf remove -y python3-pip
+# Patch any OS packages (including transitive dependencies pulled in above)
+# to the latest available errata so the image ships with security fixes.
+dnf update -y
+# Patroni's HTTP client dependencies only ship security fixes for Python >= 3.10
+# (urllib3 >= 2.7.0, requests >= 2.33.0), while the system python3 is 3.9. Install
+# patroni under python3.12 so it pulls the patched urllib3/requests, resolving
+# CVE-2026-44431 and CVE-2026-44432 (urllib3) and CVE-2026-25645 (requests). The
+# psycopg3 extra bundles libpq, so patroni no longer relies on the Python
+# 3.9-only system psycopg2.
+dnf install -y python3.12 python3.12-pip
+python3.12 -m pip install 'patroni[etcd,jsonlogger,psycopg3]==4.1.3'
+dnf remove -y python3.12-pip
 dnf clean all
 
 EOF


### PR DESCRIPTION
Remediates all Trivy CRITICAL/HIGH/MEDIUM findings in the pgedge-postgres images. The findings split into two root causes, each fixed in the shared Dockerfile:

  1. Stale OS packages — the base/install layers shipped Rocky 9.8 packages predating the latest errata (acl/libacl, giflib, glib2, glibc*, libsolv, libtiff*, python3*). Added dnf update -y to both the minimal and standard stages so every
  installed package (including transitive deps) is patched to current errata.
  2. Patroni's Python HTTP deps — urllib3 and requests (installed via pip install patroni) were stuck at vulnerable versions because their fixes require Python ≥ 3.10, while the system python3 is 3.9. Patroni is now installed under python3.12
  (from Rocky AppStream), which pulls patched urllib3 2.7.0 and requests 2.34.2. The psycopg3 extra is added so patroni bundles its own libpq-backed driver instead of relying on the Python 3.9-only system psycopg2.

Verification
All three images rebuilt from the branch (no-cache, arm64) rescanned 0 CRITICAL / 0 HIGH / 0 MEDIUM (pg16, pg17, pg18), and pg18 passed 21/21 tests including the Patroni-under-python3.12 entrypoint test.